### PR TITLE
Support dropdown option values that are longer than the parent input text box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ example/index.js
 lib
 node_modules
 npm-debug.log
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ As far as the source of the data, the component simply handles rendering and sel
 ## Rendering
 `react-bootstrap-typeahead` is intended to work with standard [Bootstrap](http://getbootstrap.com/) components and styles. It provides basic rendering for your data by default, but also allows for more advanced options should the need arise.
 
+### `overflowTo`
+By default the dropdown will be sized to match the width of the input element. If you have options that are larger than the input box you may specify `overflowTo="right"` or `overflowTo="left"` which will size the dropdown to match it's content and align to the right or the left of the input box
+
+
 ### `renderMenuItem`
 Allows you to control rendering of the entire menu item. Your function will be passed the `TypeaheadMenu` props, an individual option from your data list, and the index:
 ```
@@ -104,4 +108,5 @@ newSelectionPrefix | string | 'New selection:' | Provides the ability to specify
 options `required` | array | | Full set of options, including any pre-selected options.
 placeholder | string | | Placeholder text for the input.
 renderMenuItem | function | | Provides a hook for custom rendering of menu items. Note that this will completely override the default method, and some behaviors may need to be re-implemented.
+overflowTo | string | none | Sizes the dropdown to match it's content and aligns it to the right or the left of the input box. Use 'left' or 'right'
 selected | array | `[]` | The selected option(s) displayed in the input. Use this prop if you want to control the component via its parent.

--- a/example/example.css
+++ b/example/example.css
@@ -14,3 +14,7 @@
 .example-section {
   margin-top: 20px;
 }
+
+.overflow-section {
+  margin: 10px 0;
+}

--- a/example/example.js
+++ b/example/example.js
@@ -7,7 +7,7 @@ import Typeahead from '../src/Typeahead.react';
 import cx from 'classnames';
 import {range} from 'lodash';
 import states from './exampleData';
-
+import longLines from './exampleShakespeare';
 const CENSUS_URL = 'http://www.census.gov/2010census/data/';
 
 const Checkbox = function(props) {
@@ -27,6 +27,23 @@ const Checkbox = function(props) {
   );
 };
 
+const Radio = function(props) {
+  return (
+      <div className="radio-inline">
+        <label>
+          <input
+              checked={props.checked}
+              name={props.name}
+              value={props.value}
+              onChange={props.onChange}
+              type="radio"
+          />
+          {props.label}
+        </label>
+      </div>
+  );
+};
+
 const Example = React.createClass({
 
   getInitialState() {
@@ -38,6 +55,7 @@ const Example = React.createClass({
       multiple: false,
       preSelected: false,
       selected: [],
+      overflowTo: ''
     };
   },
 
@@ -50,6 +68,7 @@ const Example = React.createClass({
       multiple,
       preSelected,
       selected,
+      overflowTo,
     } = this.state;
 
     let props = {allowNew, disabled, multiple, selected};
@@ -130,6 +149,45 @@ const Example = React.createClass({
             <h4>Selected Options</h4>
             {selected.map((option) => option.name).join(', ')}
           </div>
+          <hr />
+          <div className="example-section">
+            <h4>Dropdown overflow</h4>
+            <div>By default the typeahead dropdown will be the same size as the input (text) element. However in some
+            cases you may want it to be larger and dropdown to the right or the left.
+            </div>
+            <div className="overflow-section">
+              <label style={{marginRight: '20px'}}>Overflow to:</label>
+              <Radio
+                  checked={"" === overflowTo}
+                  value=""
+                  label="No overflow"
+                  name="overflowTo"
+                  onChange={this._handleOverflowChange}
+              />
+              <Radio
+                  checked={"right" === overflowTo}
+                  value="right"
+                  label="Right"
+                  name="overflowTo"
+                  onChange={this._handleOverflowChange}
+              />
+              <Radio
+                  checked={"left" === overflowTo}
+                  value="left"
+                  label="Left"
+                  name="overflowTo"
+                  onChange={this._handleOverflowChange}
+              />
+            </div>
+            <div style={{width:'200px'}}>
+              <Typeahead
+                  labelKey="name"
+                  options={longLines}
+                  placeholder="Shakespeare quotes..."
+                  overflowTo={overflowTo}
+              />
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -169,6 +227,13 @@ const Example = React.createClass({
         break;
     }
 
+    this.setState(newState);
+  },
+
+  _handleOverflowChange(e) {
+    const {name, value} = e.target;
+    let newState = {};
+    newState[name] = value;
     this.setState(newState);
   },
 });

--- a/example/exampleShakespeare.js
+++ b/example/exampleShakespeare.js
@@ -1,0 +1,10 @@
+export default [
+    {name: 'To be, or not to be: that is the question'},
+    {name: 'This above all: to thine own self be true'},
+    {name: 'That it should come to this!'},
+    {name: 'There is nothing either good or bad, but thinking makes it so'},
+    {name: 'The lady doth protest too much, methinks'},
+    {name: 'Doubt that the sun doth move, doubt truth to be a liar, but never doubt I love'},
+    {name: 'Now is the winter of our discontent'},
+    {name: 'Friends, Romans, countrymen, lend me your ears; I come to bury Caesar, not to praise him'}
+];

--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -85,6 +85,11 @@ const Typeahead = React.createClass({
      * to control the component via its parent.
      */
     selected: PropTypes.array,
+    /**
+     * Specifies whether the dropdown should align to the left or the right of
+     * the input box. Valid options are 'left' (default) or 'right'
+     */
+    overflowTo: PropTypes.string,
   },
 
   getDefaultProps() {
@@ -94,6 +99,7 @@ const Typeahead = React.createClass({
       labelKey: 'label',
       multiple: false,
       selected: [],
+      overflowTo: '',
     };
   },
 
@@ -121,7 +127,7 @@ const Typeahead = React.createClass({
   },
 
   render() {
-    const {allowNew, labelKey, multiple, options} = this.props;
+    const {allowNew, labelKey, multiple, options, overflowTo} = this.props;
     const {activeIndex, selected, showMenu, text} = this.state;
 
     // Filter out options that don't match the input string or, if multiple
@@ -175,6 +181,7 @@ const Typeahead = React.createClass({
           initialResultCount={this.props.paginateResults}
           renderMenuItem={this.props.renderMenuItem}
           text={inputText}
+          overflowTo={overflowTo}
         />;
     }
 

--- a/src/TypeaheadMenu.react.js
+++ b/src/TypeaheadMenu.react.js
@@ -58,6 +58,7 @@ const TypeaheadMenu = React.createClass({
     options: PropTypes.array,
     renderMenuItem: PropTypes.func,
     text: PropTypes.string.isRequired,
+    overflowTo: PropTypes.string,
   },
 
   getDefaultProps() {
@@ -66,6 +67,7 @@ const TypeaheadMenu = React.createClass({
       initialResultCount: 100,
       maxHeight: 300,
       newSelectionPrefix: 'New selection:',
+      overflowTo: '',
     };
   },
 
@@ -81,7 +83,7 @@ const TypeaheadMenu = React.createClass({
   },
 
   render() {
-    const {maxHeight, options, renderMenuItem} = this.props;
+    const {maxHeight, options, renderMenuItem, overflowTo} = this.props;
 
     let renderer = this._renderMenuItem;
     if (renderMenuItem) {
@@ -107,13 +109,20 @@ const TypeaheadMenu = React.createClass({
       separator = <li role="separator" className="divider" />;
     }
 
+    let menuClassNames = "bootstrap-typeahead-menu";
+    let menuStyles = { maxHeight: maxHeight + 'px' };
+    if ("left" === overflowTo) {
+      menuClassNames += " dropdown-menu-right"
+    } else if ("right" === overflowTo) {
+      // no op
+    } else {
+      menuStyles['right'] = 0;
+    }
+    console.log(menuStyles);
     return (
       <Menu
-        className="bootstrap-typeahead-menu"
-        style={{
-          maxHeight: maxHeight + 'px',
-          right: 0,
-        }}>
+        className={menuClassNames}
+        style={menuStyles}>
         {results}
         {separator}
         {paginationItem}


### PR DESCRIPTION
First, thanks for creating this component, it's very useful. I had a situation in which my dropdown options were longer than the input box so they were truncated due to the right: 0 css property on the dropdown. I wanted the dropdown to expand to fit the content so I added a new prop to the Typeahead component: overflowTo which accepts 'left' or 'right'. 

overflowTo=right means the dropdown will be aligned to the left of the input box and will therefore appear to overflow to the right (useful for components on the left of the page). overflowTo=left does the opposite and would be used for components on the right of the page.

There are probably some cases where this does not work so well but it was useful for me so I thought you may want to incorporate it into your repo. I've added some docs and also updated the example page to show it in action. Feel free to let me know your thoughts