### PR TITLE
Added option for rendering a custom menu header, above the search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,5 @@ onInputChange | function | | Callback fired when user-input text changes. Receiv
 options `required` | array | | Full set of options, including any pre-selected options.
 placeholder | string | | Placeholder text for the input.
 renderMenuItemChildren | function | | Provides a hook for customized rendering of menu item contents.
+renderMenuHeader | function | | Provides a hook for rendering an optional custom menu header. 
 selected | array | `[]` | The selected option(s) displayed in the input. Use this prop if you want to control the component via its parent.

--- a/example/example.js
+++ b/example/example.js
@@ -175,10 +175,11 @@ const Example = React.createClass({
   _renderMenuHeader(options, results) {
     return (
       <div style={{marginLeft: '20px'}}>
-        Custom header: <strong>{results.length > 0 ? results.length : 0 } items found</strong>
-        <hr style={{ marginTop: '5px', marginBottom: '5px' }}/>
+        Custom header:
+        <strong>{results.length > 0 ? results.length : 0} items found</strong>
+        <hr style={{marginTop: '5px', marginBottom: '5px'}}/>
       </div>
-    )
+    );
   },
 
   _renderSelectedItems(selected) {

--- a/example/example.js
+++ b/example/example.js
@@ -44,6 +44,7 @@ const Example = React.createClass({
       alignMenu: false,
       allowNew: false,
       customMenuItemChildren: false,
+      customMenuHeader: false,
       disabled: false,
       largeDataSet: false,
       multiple: false,
@@ -59,6 +60,7 @@ const Example = React.createClass({
       alignMenu,
       allowNew,
       customMenuItemChildren,
+      customMenuHeader,
       disabled,
       largeDataSet,
       multiple,
@@ -71,6 +73,10 @@ const Example = React.createClass({
 
     if (customMenuItemChildren) {
       props.renderMenuItemChildren = this._renderMenuItemChildren;
+    }
+
+    if (customMenuHeader) {
+      props.renderMenuHeader = this._renderMenuHeader;
     }
 
     let bigData = range(0, 2000).map((option) => ({name: option.toString()}));
@@ -120,6 +126,13 @@ const Example = React.createClass({
                 Customize menu item children
               </Checkbox>
               <Checkbox
+                checked={customMenuHeader}
+                disabled={largeDataSet}
+                name="customMenuHeader"
+                onChange={this._handleChange}>
+                Render custom menu header
+              </Checkbox>
+              <Checkbox
                 checked={allowNew}
                 name="allowNew"
                 onChange={this._handleChange}>
@@ -157,6 +170,15 @@ const Example = React.createClass({
         Population: {option.population.toLocaleString()}
       </div>,
     ];
+  },
+
+  _renderMenuHeader(options, results) {
+    return (
+      <div style={{marginLeft: '20px'}}>
+        Custom header: <strong>{results.length > 0 ? results.length : 0 } items found</strong>
+        <hr style={{ marginTop: '5px', marginBottom: '5px' }}/>
+      </div>
+    )
   },
 
   _renderSelectedItems(selected) {

--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -200,8 +200,8 @@ const Typeahead = React.createClass({
           newSelectionPrefix={this.props.newSelectionPrefix}
           onClick={this._handleAddOption}
           options={filteredOptions}
-          renderMenuItemChildren={this.props.renderMenuItemChildren}
           renderMenuHeader={this.props.renderMenuHeader}
+          renderMenuItemChildren={this.props.renderMenuItemChildren}
           text={inputText}
         />;
     }

--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -91,6 +91,10 @@ const Typeahead = React.createClass({
      */
     renderMenuItemChildren: PropTypes.func,
     /**
+     * Provides a hook for rendering a header for the menu.
+     */
+    renderMenuHeader: PropTypes.func,
+    /**
      * The selected option(s) displayed in the input. Use this prop if you want
      * to control the component via its parent.
      */
@@ -197,6 +201,7 @@ const Typeahead = React.createClass({
           onClick={this._handleAddOption}
           options={filteredOptions}
           renderMenuItemChildren={this.props.renderMenuItemChildren}
+          renderMenuHeader={this.props.renderMenuHeader}
           text={inputText}
         />;
     }

--- a/src/TypeaheadMenu.react.js
+++ b/src/TypeaheadMenu.react.js
@@ -58,6 +58,7 @@ const TypeaheadMenu = React.createClass({
     newSelectionPrefix: PropTypes.string,
     options: PropTypes.array,
     renderMenuItemChildren: PropTypes.func,
+    renderMenuHeader: PropTypes.func,
     text: PropTypes.string.isRequired,
   },
 
@@ -83,7 +84,7 @@ const TypeaheadMenu = React.createClass({
   },
 
   render() {
-    const {align, maxHeight, options} = this.props;
+    const {align, maxHeight, options, renderMenuHeader} = this.props;
 
     // Render the max number of results or all results.
     let results = options.slice(0, this.state.resultCount || options.length);
@@ -114,6 +115,7 @@ const TypeaheadMenu = React.createClass({
           maxHeight: maxHeight + 'px',
           overflow: 'auto',
         }}>
+        {renderMenuHeader && renderMenuHeader(options, results)}
         {results}
         {separator}
         {paginationItem}


### PR DESCRIPTION
Hi, thanks for you work! :+1:

I've run across a use-case not covered by the existing API and decided to contribute here. I believe others might find it useful too.

What I wanted was to display a custom component in the menu just above the search results, i.e. for showing a button for creating a new item, or maybe for displaying the total/filtered number of items, etc.

It looks like the following:

![image](https://cloud.githubusercontent.com/assets/948486/16809757/1e51f710-492a-11e6-971c-b6a5780ee092.png)

What do you think?
