### PR TITLE
Update text upon receiving new selection

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -10,6 +10,8 @@ import states from './exampleData';
 require('../css/Token.css');
 require('../css/Typeahead.css');
 
+const NO_INPUT_MESSAGE = 'No text.';
+
 const Checkbox = (props) => {
   return (
     <div className="checkbox">
@@ -91,6 +93,7 @@ const Example = React.createClass({
             onInputChange={(text) => this.setState({text})}
             options={largeDataSet ? bigData : states}
             placeholder="Choose a state..."
+            selected={selected}
           />
           <ExampleSection title="Typeahead Options">
             <div className="form-group">
@@ -137,13 +140,18 @@ const Example = React.createClass({
                 onChange={this._handleChange}>
                 Align menu: {this._renderAlignmentSelector()}
               </Checkbox>
+              <button
+                className="btn btn-default"
+                onClick={this._handleClear}>
+                Clear Input
+              </button>
             </div>
           </ExampleSection>
           <ExampleSection title="Selected Items">
             {this._renderSelectedItems(selected)}
           </ExampleSection>
           <ExampleSection title="Input Text">
-            {text || <div className="text-muted">No text.</div>}
+            {text || <div className="text-muted">{NO_INPUT_MESSAGE}</div>}
           </ExampleSection>
         </div>
       </div>
@@ -207,6 +215,13 @@ const Example = React.createClass({
     }
 
     this.setState(newState);
+  },
+
+  _handleClear(e) {
+    this.setState({
+      selected: [],
+      text: this.NO_INPUT_MESSAGE,
+    });
   },
 });
 

--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -108,35 +108,34 @@ const Typeahead = React.createClass({
   },
 
   getInitialState() {
-    const {defaultSelected, labelKey, multiple} = this.props;
+    let {defaultSelected, labelKey, multiple, selected} = this.props;
 
-    let selected = this.props.selected.slice();
+    selected = selected.slice();
     if (!isEmpty(defaultSelected)) {
       selected = defaultSelected;
-    }
-
-    let selectedText = !isEmpty(selected) && head(selected)[labelKey];
-    let text = '';
-    if (!multiple && selectedText) {
-      text = selectedText;
     }
 
     return {
       activeIndex: 0,
       selected,
       showMenu: false,
-      text,
+      text: this._getText(labelKey, multiple, selected),
     };
   },
 
   componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props.selected, nextProps.selected)) {
+    let {labelKey, multiple, selected} = nextProps;
+
+    if (!isEqual(this.props.selected, selected)) {
       // If new selections are passed in via props, treat the component as a
       // controlled input.
-      this.setState({selected: nextProps.selected});
+      this.setState({
+        selected,
+        text: this._getText(labelKey, multiple, selected),
+      });
     }
 
-    if (this.props.multiple !== nextProps.multiple) {
+    if (this.props.multiple !== multiple) {
       this.setState({text: ''});
     }
   },
@@ -222,6 +221,16 @@ const Typeahead = React.createClass({
         {menu}
       </div>
     );
+  },
+
+  _getText(labelKey, multiple, selected) {
+    let selectedText = !isEmpty(selected) && head(selected)[labelKey];
+
+    if (!multiple && selectedText) {
+      return selectedText;
+    }
+
+    return '';
   },
 
   _handleFocus() {


### PR DESCRIPTION
Resetting the input field by setting `props.selected = []` would not update the text. This PR fixes that!

(Let me know if there is a more canonical way to clear the input field!)

![gif of clearing the text input](https://cl.ly/1p090s461h0i/Screen%20Recording%202016-07-14%20at%2009.04%20PM.gif)