### PR TITLE
Not invoke blur callback when the user picks from the menu

### DIFF
--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -4,6 +4,7 @@ import cx from 'classnames';
 import {isEqual, noop} from 'lodash';
 import onClickOutside from 'react-onclickoutside';
 import React, {PropTypes} from 'react';
+import findDOMNode from 'react-dom';
 
 import TokenizerInput from './TokenizerInput.react';
 import TypeaheadInput from './TypeaheadInput.react';
@@ -324,6 +325,9 @@ const Typeahead = React.createClass({
   _handleBlur(e) {
     // Note: Don't hide the menu here, since that interferes with other actions
     // like making a selection by clicking on a menu item.
+    const domElement = findDOMNode(this);
+    if(domElement.contains(e.relatedTarget)) return;
+
     this.props.onBlur(e);
   },
 


### PR DESCRIPTION
My use case is this:
When the user picks an item from the menu the blur event gets triggered, but I think conceptually when the user picks an option blur should not be triggered, since he has not moved away from the control yet