### PR TITLE
Disabled native browser autocomplete

### DIFF
--- a/src/TypeaheadInput.react.js
+++ b/src/TypeaheadInput.react.js
@@ -99,6 +99,7 @@ const TypeaheadInput = React.createClass({
             zIndex: 1,
           }}
           type="text"
+          autoComplete="off"
           value={getInputText(this.props)}
         />
         <input

--- a/src/TypeaheadInput.react.js
+++ b/src/TypeaheadInput.react.js
@@ -85,6 +85,7 @@ const TypeaheadInput = React.createClass({
         tabIndex={-1}>
         <input
           {...inputProps}
+          autoComplete="off"
           className={cx('bootstrap-typeahead-input-main', 'form-control', {
             'has-selection': !!selected.length,
           })}
@@ -99,7 +100,6 @@ const TypeaheadInput = React.createClass({
             zIndex: 1,
           }}
           type="text"
-          autoComplete="off"
           value={getInputText(this.props)}
         />
         <input


### PR DESCRIPTION
In Chrome (and maybe other browsers) the native auto completion list overlaps with the plugins suggestions.

### before

![was](https://cloud.githubusercontent.com/assets/236774/19735297/46f63bd0-9bab-11e6-877c-85197abbaa11.png)

### after

![now](https://cloud.githubusercontent.com/assets/236774/19735299/49976102-9bab-11e6-8691-8c54a3da1e77.png)
