### PR TITLE
Fix `disableOnClickOutside` and `enableOnClickOutside`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash": "^4.14.0",
     "react-highlighter": "^0.3.3",
     "react-input-autosize": "^1.1.0",
-    "react-onclickoutside": "^5.3.3",
+    "react-onclickoutside": "^5.7.0",
     "warning": "^3.0.0"
   },
   "peerDependencies": {
@@ -40,7 +40,6 @@
     "react-dom": "^0.14.0 || ^15.2.0"
   },
   "devDependencies": {
-    "babel": "^6.5.2",
     "babel-cli": "^6.11.4",
     "babel-core": "^6.11.4",
     "babel-eslint": "^6.1.2",

--- a/src/containers/tokenBehaviors.js
+++ b/src/containers/tokenBehaviors.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {omit} from 'lodash';
 import {findDOMNode} from 'react-dom';
 import onClickOutside from 'react-onclickoutside';
 
@@ -17,9 +18,12 @@ const tokenBehaviors = Component => {
     },
 
     render() {
+      const tokenProps = omit(this.props,
+        ['disableOnClickOutside', 'enableOnClickOutside']);
+
       return (
         <Component
-          {...this.props}
+          {...tokenProps}
           {...this.state}
           onBlur={this._handleBlur}
           onClick={this._handleSelect}
@@ -32,6 +36,7 @@ const tokenBehaviors = Component => {
     _handleBlur(e) {
       findDOMNode(this).blur();
       this.setState({selected: false});
+      this.props.disableOnClickOutside && this.props.disableOnClickOutside();
     },
 
     _handleKeyDown(e) {
@@ -61,6 +66,7 @@ const tokenBehaviors = Component => {
     _handleSelect(e) {
       e.stopPropagation();
       this.setState({selected: true});
+      this.props.enableOnClickOutside && this.props.enableOnClickOutside();
     },
   }));
 };


### PR DESCRIPTION
As of v.5.7.0. onclickoutside adds two additional properties `disableOnClickOutside` and `enableOnClickOutside` to a wrapped component. This leads to an unsupported property warning while spreading these props to a Token div container.

Basically this fix is doing the following:
1. Omits `disableOnClickOutside` and `enableOnClickOutside` from component props
2. Utilizes this new feature by enabling and disabling onclickoutside on token focus and blur
3. Removes `babel` dependency as deprecated.

```
ERROR: 'Warning: Unknown props `disableOnClickOutside`, `enableOnClickOutside` on <div> tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop
    in div (created by Token)
    in Token (created by Constructor)
    in Constructor (created by OnClickOutside(Constructor))
    in OnClickOutside(Constructor)'
```

`
npm WARN deprecated babel@6.5.2: Babel's CLI commands have been moved from the babel package to the babel-cli package
`

