### PR TITLE
Multiple option placeholder and return to select when only one result remains.

### DIFF
--- a/docs/Props.md
+++ b/docs/Props.md
@@ -21,6 +21,7 @@ maxHeight | number | 300 | Maximum height of the dropdown menu, in px.
 maxResults | number | 100 | Maximum number of results to display by default. Mostly done for performance reasons so as not to render too many DOM nodes in the case of large data sets.
 minLength | number | 0 | Number of input characters that must be entered before showing results.
 multiple | boolean | false | Whether or not multiple selections are allowed.
+multiplePlaceholder | string | | Placeholder text for the input when there is at least one item selected.
 name | string | | Name property for the input
 newSelectionPrefix | string | 'New selection:' | Provides the ability to specify a prefix before the user-entered text to indicate that the selection will be new. No-op unless `allowNew={true}`.
 onBlur | function | | Callback fired when the input is blurred. Receives an event.

--- a/example/examples/BasicExample.react.js
+++ b/example/examples/BasicExample.react.js
@@ -22,6 +22,7 @@ const BasicExample = React.createClass({
           multiple={multiple}
           options={options}
           placeholder="Choose a state..."
+          multiplePlaceholder="Choose additional states"
         />
         <Checkbox
           checked={multiple}

--- a/example/examples/BasicExample.react.js
+++ b/example/examples/BasicExample.react.js
@@ -20,9 +20,9 @@ const BasicExample = React.createClass({
         <Typeahead
           labelKey="name"
           multiple={multiple}
+          multiplePlaceholder="Choose additional states"
           options={options}
           placeholder="Choose a state..."
-          multiplePlaceholder="Choose additional states"
         />
         <Checkbox
           checked={multiple}

--- a/src/TokenizerInput.react.js
+++ b/src/TokenizerInput.react.js
@@ -8,7 +8,7 @@ import AutosizeInput from 'react-input-autosize';
 import Token from './Token';
 
 import getOptionLabel from './utils/getOptionLabel';
-import {BACKSPACE} from './utils/keyCode';
+import { BACKSPACE, RETURN } from './utils/keyCode';
 
 /**
  * TokenizerInput
@@ -159,6 +159,12 @@ const TokenizerInput = React.createClass({
 
           // Prevent browser "back" action.
           e.preventDefault();
+        }
+        break;
+      case RETURN:
+        if(this.props.options.length == 1 && this.props.value.length > 0) {
+          const option = this.props.options[0];
+          this.props.onAdd(option);
         }
         break;
     }

--- a/src/TokenizerInput.react.js
+++ b/src/TokenizerInput.react.js
@@ -60,7 +60,7 @@ const TokenizerInput = React.createClass({
   },
 
   render() {
-    const {bsSize, disabled, hasAux, placeholder, selected, value} = this.props;
+    const {bsSize, disabled, hasAux, placeholder, multiplePlaceholder, selected, value} = this.props;
 
     return (
       <div
@@ -99,7 +99,7 @@ const TokenizerInput = React.createClass({
           onChange={this._handleChange}
           onFocus={this.props.onFocus}
           onKeyDown={this._handleKeydown}
-          placeholder={selected.length ? null : placeholder}
+          placeholder={selected.length > 0 ? multiplePlaceholder : placeholder}
           ref="input"
           type="text"
           value={value}

--- a/src/TokenizerInput.react.js
+++ b/src/TokenizerInput.react.js
@@ -8,7 +8,7 @@ import AutosizeInput from 'react-input-autosize';
 import Token from './Token';
 
 import getOptionLabel from './utils/getOptionLabel';
-import { BACKSPACE, RETURN } from './utils/keyCode';
+import {BACKSPACE, RETURN} from './utils/keyCode';
 
 /**
  * TokenizerInput
@@ -60,7 +60,7 @@ const TokenizerInput = React.createClass({
   },
 
   render() {
-    const {bsSize, disabled, hasAux, placeholder, multiplePlaceholder, selected, value} = this.props;
+    const {bsSize, disabled, hasAux, placeholder, selected, value} = this.props;
 
     return (
       <div
@@ -99,7 +99,7 @@ const TokenizerInput = React.createClass({
           onChange={this._handleChange}
           onFocus={this.props.onFocus}
           onKeyDown={this._handleKeydown}
-          placeholder={selected.length > 0 ? multiplePlaceholder : placeholder}
+          placeholder={placeholder}
           ref="input"
           type="text"
           value={value}
@@ -162,7 +162,7 @@ const TokenizerInput = React.createClass({
         }
         break;
       case RETURN:
-        if(this.props.options.length == 1 && this.props.value.length > 0) {
+        if(this.props.options.length === 1 && this.props.value.length > 0) {
           const option = this.props.options[0];
           this.props.onAdd(option);
         }

--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -339,11 +339,12 @@ const Typeahead = React.createClass({
       multiple,
       name,
       placeholder,
+      multiplePlaceholder,
       renderToken,
     } = this.props;
     const {activeIndex, activeItem, initialItem, selected, text} = this.state;
     const Input = multiple ? TokenizerInput : TypeaheadInput;
-    const inputProps = {bsSize, disabled, name, placeholder, renderToken};
+    const inputProps = {bsSize, disabled, name, placeholder, multiplePlaceholder, renderToken};
 
     return (
       <Input

--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -99,6 +99,10 @@ const Typeahead = React.createClass({
      */
     multiple: PropTypes.bool,
     /**
+     * Placeholder text for the input when there is at least one item selected.
+     */
+    multiplePlaceholder: PropTypes.string,
+    /**
      * Callback fired when the input is blurred. Receives an event.
      */
     onBlur: PropTypes.func,

--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -338,13 +338,18 @@ const Typeahead = React.createClass({
       minLength,
       multiple,
       name,
-      placeholder,
-      multiplePlaceholder,
       renderToken,
     } = this.props;
     const {activeIndex, activeItem, initialItem, selected, text} = this.state;
     const Input = multiple ? TokenizerInput : TypeaheadInput;
-    const inputProps = {bsSize, disabled, name, placeholder, multiplePlaceholder, renderToken};
+    let placeholder = '';
+    if(multiple) {
+      placeholder = selected.length > 0 ? this.props.multiplePlaceholder :
+                                          this.props.placeholder;
+    } else {
+      placeholder = this.props.placeholder;
+    }
+    const inputProps = {bsSize, disabled, name, placeholder, renderToken};
 
     return (
       <Input

--- a/test/TokenizerInputSpec.js
+++ b/test/TokenizerInputSpec.js
@@ -7,8 +7,6 @@ import TokenizerInput from '../src/TokenizerInput';
 import options from '../example/exampleData';
 
 let props = {
-  placeholder: 'select one',
-
   labelKey: 'name',
   options,
   selected: [],

--- a/test/TokenizerInputSpec.js
+++ b/test/TokenizerInputSpec.js
@@ -7,6 +7,8 @@ import TokenizerInput from '../src/TokenizerInput';
 import options from '../example/exampleData';
 
 let props = {
+  placeholder: 'select one',
+
   labelKey: 'name',
   options,
   selected: [],


### PR DESCRIPTION
- [x] If you filter down so that there is only one item remaining in the dropdown, you should be able to hit enter and have it selected.  Currently you need to press down arrow then enter to select.
- [x] Add a prop that would be the placeholder of the input after one or more are already selected.  Currently, after you select one, the input goes blank and it's not 100% clear that you can click on that area to select more.