### PR TITLE
Make Overlay update its position more smoothly

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "classnames": "^2.2.0",
     "invariant": "^2.2.1",
     "lodash": "^4.17.2",
-    "raf": "3.3.0",
     "react-highlighter": "^0.3.3",
     "react-input-autosize": "^1.1.0",
     "react-onclickoutside": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "classnames": "^2.2.0",
     "invariant": "^2.2.1",
     "lodash": "^4.17.2",
+    "raf": "3.3.0",
     "react-highlighter": "^0.3.3",
     "react-input-autosize": "^1.1.0",
     "react-onclickoutside": "^5.7.0",

--- a/src/Overlay.react.js
+++ b/src/Overlay.react.js
@@ -53,7 +53,7 @@ const Overlay = React.createClass({
     this._updatePosition();
 
     this._updatePositionThrottled = requestAnimationFrame.bind(
-      null, 
+      null,
       this._updatePosition,
     );
 

--- a/src/Overlay.react.js
+++ b/src/Overlay.react.js
@@ -50,6 +50,7 @@ const Overlay = React.createClass({
   },
 
   componentDidMount() {
+    this._mounted = true;
     this._updatePosition();
 
     this._updatePositionThrottled = requestAnimationFrame.bind(
@@ -66,6 +67,7 @@ const Overlay = React.createClass({
   },
 
   componentWillUnmount() {
+    this._mounted = false;
     window.removeEventListener('resize', this._updatePositionThrottled);
     window.removeEventListener('scroll', this._updatePositionThrottled);
   },
@@ -101,7 +103,7 @@ const Overlay = React.createClass({
     // Positioning is only used when body is the container.
     if (
       !this.props.show ||
-      !this.isMounted() ||
+      !this._mounted ||
       !isBody(this.props.container)
     ) {
       return;

--- a/src/Overlay.react.js
+++ b/src/Overlay.react.js
@@ -1,9 +1,10 @@
 import cx from 'classnames';
-import {isEqual, throttle} from 'lodash';
+import {isEqual} from 'lodash';
 import React, {Children, cloneElement, PropTypes} from 'react';
 import {findDOMNode} from 'react-dom';
 import {Portal} from 'react-overlays';
 import componentOrElement from 'react-prop-types/lib/componentOrElement';
+import raf from 'raf';
 
 // When appending the overlay to `document.body`, clicking on it will register
 // as an "outside" click and immediately close the overlay. This classname tells
@@ -51,7 +52,8 @@ const Overlay = React.createClass({
 
   componentDidMount() {
     this._updatePosition();
-    this._updatePositionThrottled = throttle(this._updatePosition, 100);
+
+    this._updatePositionThrottled = raf.bind(null, this._updatePosition);
 
     window.addEventListener('resize', this._updatePositionThrottled);
     window.addEventListener('scroll', this._updatePositionThrottled, true);
@@ -95,7 +97,11 @@ const Overlay = React.createClass({
 
   _updatePosition() {
     // Positioning is only used when body is the container.
-    if (!isBody(this.props.container)) {
+    if (
+      !this.props.show ||
+      !this.isMounted() ||
+      !isBody(this.props.container)
+    ) {
       return;
     }
 

--- a/src/Overlay.react.js
+++ b/src/Overlay.react.js
@@ -4,7 +4,6 @@ import React, {Children, cloneElement, PropTypes} from 'react';
 import {findDOMNode} from 'react-dom';
 import {Portal} from 'react-overlays';
 import componentOrElement from 'react-prop-types/lib/componentOrElement';
-import raf from 'raf';
 
 // When appending the overlay to `document.body`, clicking on it will register
 // as an "outside" click and immediately close the overlay. This classname tells
@@ -53,7 +52,10 @@ const Overlay = React.createClass({
   componentDidMount() {
     this._updatePosition();
 
-    this._updatePositionThrottled = raf.bind(null, this._updatePosition);
+    this._updatePositionThrottled = requestAnimationFrame.bind(
+      null, 
+      this._updatePosition,
+    );
 
     window.addEventListener('resize', this._updatePositionThrottled);
     window.addEventListener('scroll', this._updatePositionThrottled, true);


### PR DESCRIPTION
If the Overlay is mounted at `<body />`, it jitters while page scrolls. This happens because `<Overlay />` is repositioned with throttled call.

To mitigate the jitter issue, replace`throttle` with `raf` (a.k.a `requestAnimationFrame`) instead.

**before**
![before](https://cloud.githubusercontent.com/assets/1504439/24976958/542e88e4-1f80-11e7-98a3-b8f643b76200.gif)

**after**
![after](https://cloud.githubusercontent.com/assets/1504439/24976967/5b65e85a-1f80-11e7-9049-387b1cb74581.gif)