### PR TITLE
Add onClick event on MenuItemContainer

### DIFF
--- a/src/containers/menuItemContainer.js
+++ b/src/containers/menuItemContainer.js
@@ -16,6 +16,11 @@ const menuItemContainer = Component => (
         PropTypes.string,
       ]).isRequired,
       position: PropTypes.number,
+      onClick: PropTypes.func
+    },
+
+    defaultProps: {
+      onClick: () => true
     },
 
     contextTypes: {
@@ -59,7 +64,7 @@ const menuItemContainer = Component => (
         <Component
           {...props}
           active={activeIndex === position}
-          onClick={() => onMenuItemClick(option)}
+          onClick={() => this.props.onClick() !== false && onMenuItemClick(option)}
         />
       );
     },


### PR DESCRIPTION
Add the possibility to define the onClick event on the MenuItemContainer component.
The default behavior is overrided except if onClick return false.