### PR TITLE
When rendering a dropup, the menu should be rendered first.

### DIFF
--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -277,9 +277,10 @@ const Typeahead = createReactClass({
           'dropup': dropup,
         }, className)}
         style={{position: 'relative'}}>
+        {dropup ? this._renderMenu(results, shouldPaginate) : null}
         {this._renderInput(results)}
         {this._renderAux()}
-        {this._renderMenu(results, shouldPaginate)}
+        {!dropup ? this._renderMenu(results, shouldPaginate) : null}
       </div>
     );
   },


### PR DESCRIPTION
Using the BS4 rendering method, I had a small issue with the dropup actually covering the input method. 

It was resolved by moving the menu render call a before the actual input field, as shown in the change here.