### PR TITLE
add ability to set tabIndex prop for input and tokens

### DIFF
--- a/src/Token.react.js
+++ b/src/Token.react.js
@@ -21,7 +21,14 @@ class Token extends React.Component {
   }
 
   _renderRemoveableToken() {
-    const {children, className, onRemove, selected, ...otherProps} = this.props;
+    const {
+      children,
+      className,
+      onRemove,
+      selected,
+      tabIndex,
+      ...otherProps
+    } = this.props;
 
     return (
       <div
@@ -29,7 +36,7 @@ class Token extends React.Component {
         className={cx('token', 'token-removeable', {
           'token-selected': selected,
         }, className)}
-        tabIndex={0}>
+        tabIndex={0 + tabIndex}>
         {children}
         <span
           className="close-button"

--- a/src/TokenizerInput.react.js
+++ b/src/TokenizerInput.react.js
@@ -33,7 +33,15 @@ class TokenizerInput extends React.Component {
   }
 
   render() {
-    const {bsSize, disabled, hasAux, placeholder, selected, value} = this.props;
+    const {
+      bsSize,
+      disabled,
+      hasAux,
+      placeholder,
+      selected,
+      tabIndex,
+      value,
+    } = this.props;
 
     return (
       <div
@@ -75,6 +83,7 @@ class TokenizerInput extends React.Component {
           onKeyDown={this._handleKeydown}
           placeholder={selected.length ? null : placeholder}
           ref="input"
+          tabIndex={0 + tabIndex}
           type="text"
           value={value}
         />
@@ -91,7 +100,13 @@ class TokenizerInput extends React.Component {
   }
 
   _renderToken(option, idx) {
-    const {disabled, labelKey, onRemove, renderToken} = this.props;
+    const {
+      disabled,
+      labelKey,
+      onRemove,
+      renderToken,
+      tabIndex,
+    } = this.props;
     const onRemoveWrapped = () => onRemove(option);
 
     if (renderToken) {
@@ -102,7 +117,8 @@ class TokenizerInput extends React.Component {
       <Token
         disabled={disabled}
         key={idx}
-        onRemove={onRemoveWrapped}>
+        onRemove={onRemoveWrapped}
+        tabIndex={tabIndex}>
         {getOptionLabel(option, labelKey)}
       </Token>
     );

--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import {find, isEqual, noop} from 'lodash';
+import {find, isEqual, isFinite, noop} from 'lodash';
 import onClickOutside from 'react-onclickoutside';
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -194,10 +194,18 @@ class Typeahead extends React.Component {
       name,
       placeholder,
       renderToken,
+      tabIndex,
     } = this.props;
     const {activeIndex, activeItem, initialItem, selected, text} = this.state;
     const Input = multiple ? TokenizerInput : TypeaheadInput;
-    const inputProps = {bsSize, disabled, name, placeholder, renderToken};
+    const inputProps = {
+      bsSize,
+      disabled,
+      name,
+      placeholder,
+      renderToken,
+      tabIndex,
+    };
 
     return (
       <Input
@@ -595,6 +603,24 @@ Typeahead.propTypes = {
    * Propagate <RETURN> event to parent form.
    */
   submitFormOnEnter: PropTypes.bool,
+  /**
+   * Set a custom tabindex value.
+   */
+  tabIndex: function(props, propName, componentName) {
+    const prop = props[propName];
+    if (
+      !isFinite(prop) ||
+      prop < -1
+    ) {
+      return new Error(
+        `
+          Invalid prop \`${propName}\` supplied to \`${componentName}\`.
+          Validation failed; ${propName} must be a number greater than or equal
+          to -1.
+        `
+      );
+    }
+  },
 };
 
 Typeahead.defaultProps = {
@@ -620,6 +646,7 @@ Typeahead.defaultProps = {
   paginate: true,
   selected: [],
   submitFormOnEnter: false,
+  tabIndex: 0,
 };
 
 Typeahead.childContextTypes = {

--- a/src/TypeaheadInput.react.js
+++ b/src/TypeaheadInput.react.js
@@ -46,6 +46,7 @@ class TypeaheadInput extends React.Component {
       onFocus,
       placeholder,
       selected,
+      tabIndex,
       value,
     } = this.props;
 
@@ -85,6 +86,7 @@ class TypeaheadInput extends React.Component {
             position: 'relative',
             zIndex: 1,
           }}
+          tabIndex={0 + tabIndex}
         />
         <TextInput
           bsSize={bsSize}


### PR DESCRIPTION
tabIndex prop must be a number greater than or equal to -1

**Motivation**
because of the necessity to update tokens as well as the input (when `multiple` is true), while there is a possibility to relate this to #79 (_API for setting input-specific props_), however, as discussed in #206 (_Custom tabIndex prop_), I would suggest the option is kept separate.