### PR TITLE
Stop multiple attribute being set on input

### DIFF
--- a/src/HintedInput.react.js
+++ b/src/HintedInput.react.js
@@ -14,7 +14,14 @@ const STYLES = {
 
 class HintedInput extends React.Component {
   render() {
-    const {className, hintText, inputRef, isFocused, ...props} = this.props;
+    const {
+      className,
+      hintText,
+      inputRef,
+      isFocused,
+      multiple,
+      ...props
+    } = this.props;
 
     return (
       <div style={{display: 'inline-block', position: 'relative'}}>


### PR DESCRIPTION
I ran in to this as a problem when using [react-redux-form](https://github.com/davidkpiano/react-redux-form). When it finds an input with the `multiple` attribute it treats it differently.