### PR TITLE
Added trimQuery to AsyncTypeahead

### DIFF
--- a/docs/Props.md
+++ b/docs/Props.md
@@ -43,6 +43,7 @@ Name | Type | Default | Description
 -----|------|---------|------------
 delay | number | 200 | Delay, in milliseconds, before performing search.
 onSearch `required` | function | | Callback to perform when the search is executed.
+trimQuery | bool | true | Whether or not the query should have white space trimmed before searching.
 options | array | `[]` | Options to be passed to the typeahead. Will typically be the query results, but can also be initial default options.
 promptText | string | 'Type to search...' | Text displayed in the menu when there is no user input.
 searchText | string | 'Searching...' | Text to display in the menu while the request is pending.

--- a/src/containers/asyncContainer.js
+++ b/src/containers/asyncContainer.js
@@ -128,10 +128,11 @@ const asyncContainer = Typeahead => {
         minLength,
         multiple,
         onSearch,
+        trimQuery,
         useCache,
       } = this.props;
 
-      let query = initialQuery.trim();
+      let query = trimQuery ? initialQuery.trim() : initialQuery;
       if (!caseSensitive) {
         query = query.toLowerCase();
       }
@@ -168,6 +169,11 @@ const asyncContainer = Typeahead => {
      */
     onSearch: PropTypes.func.isRequired,
     /**
+     * Whether or not the query should have white space trimmed before
+     * searching.
+     */
+    trimQuery: PropTypes.bool,
+    /**
      * Options to be passed to the typeahead. Will typically be the query
      * results, but can also be initial default options.
      */
@@ -188,6 +194,7 @@ const asyncContainer = Typeahead => {
 
   Container.defaultProps = {
     delay: DEFAULT_DELAY_MS,
+    trimQuery: true,
     minLength: 2,
     options: [],
     promptText: 'Type to search...',

--- a/test/AsyncTypeaheadSpec.js
+++ b/test/AsyncTypeaheadSpec.js
@@ -87,6 +87,39 @@ describe('<AsyncTypeahead>', () => {
     });
   });
 
+  it('should trim white space from the query', done => {
+    let afterSearch = '';
+
+    const instance = getTypeaheadInstance({
+      ...defaultProps,
+      onSearch(query) {
+        afterSearch = query;
+      },
+    });
+
+    performSearch(' search ', instance, () => {
+      expect(afterSearch).to.equal('search');
+      done();
+    });
+  });
+
+  it('should not trim white space from the query', done => {
+    let afterSearch = '';
+
+    const instance = getTypeaheadInstance({
+      ...defaultProps,
+      onSearch(query) {
+        afterSearch = query;
+      },
+      trimQuery: false,
+    });
+
+    performSearch(' search ', instance, () => {
+      expect(afterSearch).to.equal(' search ');
+      done();
+    });
+  });
+
   it('should use cached results and not perform a new search', done => {
     let searchCount = 0;
 


### PR DESCRIPTION
I added the trimQuery prop to allow for the use case, where typing a query that is equal in length to `minLength` but ends in a space character, does not trigger the search.

The problem with such a query not triggering a search, is that while it may not trigger a search, it does show the current options from previous searches.

So if the user previously triggered a search, e.g. `Foo`, and then cleared the search, and started searching for `ba `, results for `Foo` are displayed. Even though the user is expecting to see completely different results.

The `trimQuery` prop is defaulted to true, to keep the original behaviour.