### PR TITLE
Pass event as 2nd arg to onInputChange in TypeaheadInput

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -29,8 +29,8 @@ See full documentation in the [Rendering section](Rendering.md).
 ##### `onChange(selectedItems)`
 Invoked when the set of selections changes (ie: an item is added or removed). For consistency, `selectedItems` is always an array of selections, even multi-selection is not enabled.
 
-##### `onInputChange(text)`
-Invoked when the input value changes. Receives the string value of the input (`text`).
+##### `onInputChange(text, event)`
+Invoked when the input value changes. Receives the string value of the input (`text`) and the `event` object.
 
 ##### `onPaginate(event)`
 Invoked when the pagination menu item is clicked. Receives an event.

--- a/src/TokenizerInput.react.js
+++ b/src/TokenizerInput.react.js
@@ -114,7 +114,7 @@ class TokenizerInput extends React.Component {
   }
 
   _handleChange(e) {
-    this.props.onChange(e.target.value);
+    this.props.onChange(e.target.value, e);
   }
 
   _handleKeydown(e) {

--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -332,14 +332,14 @@ class Typeahead extends React.Component {
     this.setState({initialItem});
   }
 
-  _handleTextChange = text => {
+  _handleTextChange = (text, event) => {
     const {activeIndex, activeItem} = getInitialState(this.props);
     this.setState({
       activeIndex,
       activeItem,
       showMenu: true,
     });
-    this._updateText(text);
+    this._updateText(text, event);
   }
 
   _handleKeydown = (options, e) => {
@@ -469,9 +469,9 @@ class Typeahead extends React.Component {
     this.props.onChange(selected);
   }
 
-  _updateText = text => {
+  _updateText = (text, event) => {
     this.setState({text});
-    this.props.onInputChange(text);
+    this.props.onInputChange(text, event);
   }
 }
 

--- a/src/TypeaheadInput.react.js
+++ b/src/TypeaheadInput.react.js
@@ -126,7 +126,7 @@ class TypeaheadInput extends React.Component {
     const {onRemove, selected} = this.props;
     !!selected.length && onRemove(head(selected));
 
-    this.props.onChange(e.target.value);
+    this.props.onChange(e.target.value, e);
   }
 
   /**


### PR DESCRIPTION
This is related to issue #202 and provides the `event` as a second argument for `onInputChange` on the `TypeaheadInput` and the `TokenizerInput`. Let me know if anything should change, and thanks for your work on this package.   