### PR TITLE
Stop propagation from close button to the containing token element.

### DIFF
--- a/src/Token.react.js
+++ b/src/Token.react.js
@@ -14,6 +14,12 @@ import tokenContainer from './containers/tokenContainer';
 class Token extends React.Component {
   displayName = 'Token';
 
+  constructor(props) {
+    super(props);
+
+    this._handleRemove = this._handleRemove.bind(this);
+  }
+
   render() {
     return this.props.onRemove && !this.props.disabled ?
       this._renderRemoveableToken() :
@@ -32,7 +38,7 @@ class Token extends React.Component {
         {children}
         <span
           className="rbt-token-close-button"
-          onClick={onRemove}
+          onClick={this._handleRemove}
           role="button">
           &times;
         </span>
@@ -59,6 +65,11 @@ class Token extends React.Component {
         {children}
       </div>
     );
+  }
+
+  _handleRemove(e) {
+    e.stopPropagation();
+    this.props.onRemove(e);
   }
 }
 


### PR DESCRIPTION
Containing token component has `onClick` event connected to [this handler](https://github.com/ericgio/react-bootstrap-typeahead/blob/5ab7197e6da406b11e05449751316154507c8c8c/src/containers/tokenContainer.js#L83) - thus clicking remove button triggered select handler which in order called `enableOnClickOutside`.
