### PR TITLE
ignoreDiacritics removes combining diacritics 

### DIFF
--- a/src/utils/stripDiacritics.js
+++ b/src/utils/stripDiacritics.js
@@ -115,5 +115,7 @@ for (let ii=0; ii < map.length; ii++) {
 
 // "what?" version ... http://jsperf.com/diacritics/12
 export default function stripDiacritics(str) {
-  return str.replace(/[^\u0000-\u007E]/g, (a) => diacriticsMap[a] || a);
+  // Remove all combining diacritics.
+  const strNoCombiningDiacritics = str.replace(/[\u0300-\u036F]/g, '');
+  return strNoCombiningDiacritics.replace(/[^\u0000-\u007E]/g, (a) => diacriticsMap[a] || a);
 }

--- a/src/utils/stripDiacritics.js
+++ b/src/utils/stripDiacritics.js
@@ -116,6 +116,6 @@ for (let ii=0; ii < map.length; ii++) {
 // "what?" version ... http://jsperf.com/diacritics/12
 export default function stripDiacritics(str) {
   // Remove all combining diacritics.
-  const strNoCombiningDiacritics = str.replace(/[\u0300-\u036F]/g, '');
-  return strNoCombiningDiacritics.replace(/[^\u0000-\u007E]/g, (a) => diacriticsMap[a] || a);
+  const strStrip = str.replace(/[\u0300-\u036F]/g, '');
+  return strStrip.replace(/[^\u0000-\u007E]/g, (a) => diacriticsMap[a] || a);
 }


### PR DESCRIPTION
##Resolves #279

This pre-processes the string sent into stripDiacritics() by removing everything in the combining diacritics range (https://en.wikipedia.org/wiki/Combining_Diacritical_Marks). The one potential issue it does not address is highlighting, as the highlighting system does not know where in the substring to make a match after the comparison string is altered.
