### PR TITLE
Make sure that `Overlay` can render with empty children

### DIFF
--- a/src/Overlay.react.js
+++ b/src/Overlay.react.js
@@ -75,7 +75,13 @@ class Overlay extends React.Component {
     }
 
     const {container, children} = this.props;
-    let child = Children.only(children);
+
+    let child;
+    if (Children.count(children) > 0) {
+      child = Children.only(children);
+    } else {
+      return null;
+    }
 
     // When not attaching the overlay to `document.body` treat the child as a
     // simple inline element.
@@ -139,6 +145,7 @@ class Overlay extends React.Component {
 }
 
 Overlay.propTypes = {
+  children: PropTypes.element,
   container: componentOrElement.isRequired,
   onMenuHide: PropTypes.func.isRequired,
   onMenuShow: PropTypes.func.isRequired,

--- a/test/components/OverlaySpec.js
+++ b/test/components/OverlaySpec.js
@@ -9,7 +9,6 @@ import Overlay from '../../src/Overlay';
 describe('<Overlay>', () => {
   describe('shallow behaviors', () => {
     let wrapper;
-
     beforeEach(() => {
       const div = document.createElement('div');
       wrapper = shallow(
@@ -33,6 +32,26 @@ describe('<Overlay>', () => {
       wrapper.setProps({show: true});
       expect(wrapper.type()).to.equal('div');
       expect(wrapper.text()).to.equal('This is the menu');
+    });
+
+    it('returns `null` when child is `null`', () => {
+      wrapper.setProps({children: null, show: true});
+      expect(wrapper.length).to.equal(1);
+      expect(wrapper.type()).to.equal(null);
+    });
+
+    it('throws when has multiple children', () => {
+      expect(() => {
+        wrapper.setProps({
+          children: [
+            <div key="1"/>,
+            <div key="2"/>,
+          ],
+          show: true,
+        });
+      }).to.throw(
+        'React.Children.only expected to receive a single React element child.'
+      );
     });
 
     it('calls `onMenuShow` and `onMenuHide`', () => {


### PR DESCRIPTION
Rather than the overlay throwing an error when it is passed more or less than one child, this allows it to now be passed 0 children as a way of controlling the visibility of the menu without having to pass an empty div, and rendering it + the portal that wraps it.

Passing more than one child results in the same functionality as previously. (thrown error from react)