### PR TITLE
Export the default TypeaheadMenu

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -7,6 +7,7 @@ The components and higher-order components (HOCs) described below are publicly e
   - [`<Highlighter>`](#highlighter)
   - [`<Menu>`](#menu)
   - [`<MenuItem>`](#menuitem)
+  - [`<TypeaheadMenu>`](#typeaheadmenu)
   - [`<Token>`](#token)
 - [Higher-Order Components](#higher-order-components)
   - [`asyncContainer`](#asynccontainer)
@@ -101,13 +102,16 @@ Provides the markup for a Bootstrap menu, along with some extra functionality fo
 ### `<MenuItem>`
 Provides the markup for a Bootstrap menu item, but is wrapped with the `menuItemContainer` HOC to ensure proper behavior within the typeahead context. Provided for use if a more customized `Menu` is desired.
 
+### `<TypeaheadMenu>`
+The default menu which is rendered by the `Typeahead` component. Can be used in a custom `renderMenu` function for wrapping or modifying the props passed to it without having to re-implemen the default functionality.
+
 #### Props
 
 ##### `option: Object` (required)
 The data item to be displayed.
 
 ##### `position: Number`
-The position of the item as rendered in the menu. Allows the top-level `Typeahead`component to be be aware of the item's position despite any custom ordering or grouping in `renderMenu`. **Note:** The value must be a unique, zero-based, sequential integer for proper behavior when keying through the menu.
+The position of the item as rendered in the menu. Allows the top-level `Typeahead` component to be be aware of the item's position despite any custom ordering or grouping in `renderMenu`. **Note:** The value must be a unique, zero-based, sequential integer for proper behavior when keying through the menu.
 
 ### `<Token>`
 Individual token component, most commonly for use within `renderToken` to customize the `Token` contents.

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export Menu from './Menu.react';
 export MenuItem from './MenuItem.react';
 export Token from './Token.react';
 export Typeahead from './Typeahead.react';
+export TypeaheadMenu from './TypeaheadMenu.react';
 
 // HOCs
 export asyncContainer from './containers/asyncContainer';

--- a/test/components/indexSpec.js
+++ b/test/components/indexSpec.js
@@ -1,0 +1,65 @@
+import {expect} from 'chai';
+import {
+  AsyncTypeahead,
+  Highlighter,
+  Menu,
+  MenuItem,
+  Token,
+  Typeahead,
+  TypeaheadMenu,
+  asyncContainer,
+  menuItemContainer,
+  tokenContainer,
+} from '../../src';
+import aAsyncTypeahead from '../../src/AsyncTypeahead.react';
+import aHighlighter from '../../src/Highlighter.react';
+import aMenu from '../../src/Menu.react';
+import aMenuItem from '../../src/MenuItem.react';
+import aToken from '../../src/Token.react';
+import aTypeahead from '../../src/Typeahead.react';
+import aTypeaheadMenu from '../../src/TypeaheadMenu.react';
+import aasyncContainer from '../../src/containers/asyncContainer';
+import amenuItemContainer from '../../src/containers/menuItemContainer';
+import atokenContainer from '../../src/containers/tokenContainer';
+
+describe('<HintedInput>', () => {
+  it('AsyncTypeahead is exported', () => {
+    expect(AsyncTypeahead).to.equal(aAsyncTypeahead);
+  });
+
+  it('Highlighter is exported', () => {
+    expect(Highlighter).to.equal(aHighlighter);
+  });
+
+  it('Menu is exported', () => {
+    expect(Menu).to.equal(aMenu);
+  });
+
+  it('MenuItem is exported', () => {
+    expect(MenuItem).to.equal(aMenuItem);
+  });
+
+  it('Token is exported', () => {
+    expect(Token).to.equal(aToken);
+  });
+
+  it('Typeahead is exported', () => {
+    expect(Typeahead).to.equal(aTypeahead);
+  });
+
+  it('TypeaheadMenu is exported', () => {
+    expect(TypeaheadMenu).to.equal(aTypeaheadMenu);
+  });
+
+  it('asyncContainer is exported', () => {
+    expect(asyncContainer).to.equal(aasyncContainer);
+  });
+
+  it('menuItemContainer is exported', () => {
+    expect(menuItemContainer).to.equal(amenuItemContainer);
+  });
+
+  it('tokenContainer is exported', () => {
+    expect(tokenContainer).to.equal(atokenContainer);
+  });
+});


### PR DESCRIPTION
This PR exposes the default Typeahead menu to allow users to wrap it or use it in a custom `renderMenu` function in their own way without having to re-implement it themselves.

I also added tests for the index.js so we can be sure everything we expect to be exporting is exported.