### PR TITLE
Handle empty-string search text in AsyncTypeahead

### DIFF
--- a/src/containers/asyncContainer.js
+++ b/src/containers/asyncContainer.js
@@ -107,7 +107,7 @@ const asyncContainer = (Typeahead) => {
 
       this.setState({query});
 
-      if (!query || (minLength && query.length < minLength)) {
+      if (typeof(query) === 'string' && isFinite(minLength) && query.length < minLength) {
         return;
       }
 


### PR DESCRIPTION
First of all, good library, thanks for making it. Saved me a lot of time. I am using an older version of `react-bootstrap-typeahead` in my product. I ran into an issue with it where if a user deletes all the text from an input, they are still shown the last searched set of options to select a value from. I needed the typeahead to fetch a new, limited set of options for an empty input, so that a user can pick a different option from the ones they were shown for the last search text.

After some digging, I found this line to be the culprit. I couldn't really upgrade my project to the latest version of `react-bootstrap-typeahead`, so I just copied the compiled JS files from node_modules and made this change, and now, in my project, the typeahead behaves properly when a user clears the search text from the input.

On going through the source code in this git repository, I found the same line of code, which would have caused the same issue to other users using `react-bootstrap-typeahead`, So making this PR. Hope you see the point of it.