### PR TITLE
Pass active flag in options to MenuItem

### DIFF
--- a/src/TypeaheadMenu.react.js
+++ b/src/TypeaheadMenu.react.js
@@ -37,6 +37,7 @@ class TypeaheadMenu extends React.Component {
 
     const menuItemProps = {
       disabled: option.disabled,
+      active: option.active,
       key: idx,
       label,
       option,


### PR DESCRIPTION
[MenuItem currently has code to set the "active" class if an option has that flag](https://github.com/ericgio/react-bootstrap-typeahead/blob/master/src/MenuItem.react.js#L20), but [TypeaheadMenu only sends the "disabled" flag](https://github.com/ericgio/react-bootstrap-typeahead/blob/master/src/TypeaheadMenu.react.js#L39).

This PR passes the active flag to MenuItem to allow users to mark particular options as "active" for styling purposes.