### PR TITLE
Fixed issue with allowNew callback option not working with async

### DIFF
--- a/src/containers/asyncContainer.js
+++ b/src/containers/asyncContainer.js
@@ -46,7 +46,7 @@ const asyncContainer = (Typeahead) => {
     }
 
     render() {
-      const {allowNew, options, useCache, ...props} = this.props;
+      const {options, useCache, ...props} = this.props;
       const cachedQuery = this._cache[this.state.query];
       const emptyLabel = this._getEmptyLabel();
 
@@ -54,16 +54,17 @@ const asyncContainer = (Typeahead) => {
       // the process of searching. The logic for whether or not to display the
       // custom menu option is basically the same as whether we display the
       // empty label, so use that as a proxy.
-      const shouldAllowNew =
-          (allowNew && emptyLabel === props.emptyLabel) ||
-          // Unless allowNew is a function,
-          // in which case it is up to the function to decide
-          typeof allowNew === 'function';
+      let allowNew = props.allowNew && emptyLabel === props.emptyLabel;
+      // Unless allowNew is a function,
+      // in which case it is up to the function to decide
+      if (typeof props.allowNew === 'function') {
+        allowNew = props.allowNew;
+      }
 
       return (
         <Typeahead
           {...props}
-          allowNew={shouldAllowNew ? allowNew : false}
+          allowNew={allowNew}
           emptyLabel={emptyLabel}
           onInputChange={this._handleInputChange}
           options={useCache && cachedQuery ? cachedQuery : options}

--- a/src/containers/asyncContainer.js
+++ b/src/containers/asyncContainer.js
@@ -54,12 +54,16 @@ const asyncContainer = (Typeahead) => {
       // the process of searching. The logic for whether or not to display the
       // custom menu option is basically the same as whether we display the
       // empty label, so use that as a proxy.
-      const shouldAllowNew = allowNew && emptyLabel === props.emptyLabel;
+      const shouldAllowNew =
+          (allowNew && emptyLabel === props.emptyLabel) ||
+          // Unless allowNew is a function,
+          // in which case it is up to the function to decide
+          typeof allowNew === 'function';
 
       return (
         <Typeahead
           {...props}
-          allowNew={shouldAllowNew}
+          allowNew={shouldAllowNew ? allowNew : false}
           emptyLabel={emptyLabel}
           onInputChange={this._handleInputChange}
           options={useCache && cachedQuery ? cachedQuery : options}

--- a/test/components/AsyncTypeaheadSpec.js
+++ b/test/components/AsyncTypeaheadSpec.js
@@ -187,4 +187,35 @@ describe('<AsyncTypeahead>', () => {
     change(wrapper, 'x');
   });
 
+  it('adds a custom option when exact match is found ' +
+      'and `allowNew` returns true', (done) => {
+    const emptyLabel = 'No results...';
+    const newSelectionPrefix = 'New selection: ';
+    const text = 'zzz';
+
+    wrapper.setProps({
+      allowNew: (results, props) => true,
+      emptyLabel,
+      isLoading: true,
+      newSelectionPrefix,
+      useCache: false,
+    });
+
+    focus(wrapper);
+
+    search(wrapper, text, () => {
+      wrapper.setProps({
+        isLoading: false,
+        options: [text],
+      });
+
+      focus(wrapper);
+      const menuItems = getMenuItems(wrapper);
+
+      expect(menuItems.length).to.equal(2);
+      expect(menuItems.at(0).text()).to.equal(text);
+      expect(menuItems.at(1).text()).to.equal(`${newSelectionPrefix}${text}`);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
So after attempting to use the latest build to leverage the allowNew callback option I added, things were working. I dug in and found out that AsyncTypeahead has a condition check with allowNew, so even if allowNew is a function, a boolean is passed from AsyncTypeahead to Typeahead.

I'm not sure if this is the best way to fix it, but I've added a test to verify it works and the existing tests are all fine too.