### PR TITLE
Fix react 16.5.0 warning

### DIFF
--- a/src/containers/hintContainer.js
+++ b/src/containers/hintContainer.js
@@ -54,6 +54,7 @@ function hintContainer(Input) {
           <input
             aria-hidden
             className="rbt-input-hint"
+            readOnly
             ref={(hint) => this._hint = hint}
             style={{
               backgroundColor: 'transparent',
@@ -66,7 +67,6 @@ function hintContainer(Input) {
               top: 0,
             }}
             tabIndex={-1}
-            readOnly
             value={this.context.hintText}
           />
         </div>

--- a/src/containers/hintContainer.js
+++ b/src/containers/hintContainer.js
@@ -66,6 +66,7 @@ function hintContainer(Input) {
               top: 0,
             }}
             tabIndex={-1}
+            readOnly
             value={this.context.hintText}
           />
         </div>


### PR DESCRIPTION
> "You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`."

I think this is readOnly but I'm not 100% sure.