### PR TITLE
Remove href from MenuItem to prevent unwanted redirect

### DIFF
--- a/src/MenuItem.react.js
+++ b/src/MenuItem.react.js
@@ -28,7 +28,6 @@ class BaseMenuItem extends React.Component {
         className={cx(conditionalClassNames, className)}>
         <a
           className={cx('dropdown-item', conditionalClassNames)}
-          href="#"
           onClick={this._handleClick}
           onMouseDown={onMouseDown}>
           {children}

--- a/test/components/MenuItemSpec.js
+++ b/test/components/MenuItemSpec.js
@@ -66,6 +66,10 @@ describe('<MenuItem>', () => {
     expect(menuItem.find('a')).to.have.length(1);
   });
 
+  it('does not include a href to prevent unwanted redirect', () => {
+    expect(menuItem.find('a').prop('href')).to.be.undefined
+  })
+
   it('changes the active state of the menu item', () => {
     expect(menuItem.hasClass('active')).to.equal(false);
 


### PR DESCRIPTION
When using the component over a SPA application, the MenuItem is redirecting to the base route.

Example:
The component is over this route: `/#/invoices`, when I click in a MenuItem, the browser is redirected to `/#`.

* I couldn't perform this test, I didn't find e2e tests to do it.
* The pointer mouse is ok without the href.