### PR TITLE
Multiword highlighter for longer sentences

### DIFF
--- a/src/Highlighter.react.js
+++ b/src/Highlighter.react.js
@@ -22,10 +22,10 @@ class Highlighter extends React.PureComponent {
 
   _renderHighlightedChildren() {
     const children = [];
-    let remaining = this.props.children;
+    let {search, children: remaining, ...options} = this.props;
 
     while (remaining) {
-      const bounds = getMatchBounds(remaining, this.props.search);
+      const bounds = getMatchBounds(remaining, search, options);
 
       if (!bounds) {
         this._count++;
@@ -68,7 +68,9 @@ class Highlighter extends React.PureComponent {
 }
 
 Highlighter.propTypes = {
+  beginningOnly: PropTypes.boolean,
   children: PropTypes.string.isRequired,
+  multiword: PropTypes.boolean,
   search: PropTypes.string.isRequired,
 };
 

--- a/src/utils/getMatchBounds.js
+++ b/src/utils/getMatchBounds.js
@@ -4,9 +4,20 @@ import stripDiacritics from './stripDiacritics';
 const CASE_INSENSITIVE = 'i';
 const COMBINING_MARKS = /[\u0300-\u036F]/;
 
-export default function getMatchBounds(subject, search) {
+export default function getMatchBounds(subject, search, options = {}) {
+  const {multiword = false, beginningOnly = false} = options;
+  const boundry = beginningOnly ? '\\b' : '';
+  search = boundry + escapeStringRegexp(stripDiacritics(search));
+
+  if (multiword) {
+    const searchsplit = search.split(/\s+/);
+    if (searchsplit.length > 1) {
+      search += '|' + boundry + searchsplit.join('|' + boundry);
+    }
+  }
+
   search = new RegExp(
-    escapeStringRegexp(stripDiacritics(search)),
+    search,
     CASE_INSENSITIVE
   );
 

--- a/test/components/HighlighterSpec.js
+++ b/test/components/HighlighterSpec.js
@@ -55,4 +55,56 @@ describe('<Highlighter>', () => {
     expect(matches.length).to.equal(1);
     expect(matches.first().text()).to.equal('Krakó');
   });
+    matches = highlighter
+      .setProps({search: 'nia cal'})
+      .find('mark');
+
+    expect(matches.length).to.equal(0);
+  });
+
+    beforeEach(() => {
+      highlighter = shallow(
+        <Highlighter multiword={true} search="">
+          California is warm
+        </Highlighter>
+      );
+    });
+      matches = highlighter
+        .setProps({search: 'nia cal'})
+        .find('mark');
+
+      expect(matches.length).to.equal(2);
+      expect(matches.first().text()).to.equal('Cal');
+      expect(matches.at(1).text()).to.equal('nia');
+    });
+
+    it('combined match', () => {
+      matches = highlighter
+        .setProps({search: 'is warm'})
+        .find('mark');
+
+      expect(matches.length).to.equal(1);
+      expect(matches.first().text()).to.equal('is warm');
+    });
+  });
+
+  describe('beginningOnly', function() {
+    beforeEach(() => {
+      highlighter = shallow(
+        <Highlighter beginningOnly={true} multiword={true} search="">
+          California is warm
+        </Highlighter>
+      );
+    });
+
+    it('not matches partly', () => {
+      matches = highlighter
+        .setProps({search: 'nia cal warm'})
+        .find('mark');
+
+      expect(matches.length).to.equal(2);
+      expect(matches.first().text()).to.equal('Cal');
+      expect(matches.at(1).text()).to.equal('warm');
+    });
+  });
 });

--- a/test/components/HighlighterSpec.js
+++ b/test/components/HighlighterSpec.js
@@ -55,6 +55,8 @@ describe('<Highlighter>', () => {
     expect(matches.length).to.equal(1);
     expect(matches.first().text()).to.equal('Krakó');
   });
+
+  it('matches multiword disabled by default', () => {
     matches = highlighter
       .setProps({search: 'nia cal'})
       .find('mark');
@@ -62,6 +64,7 @@ describe('<Highlighter>', () => {
     expect(matches.length).to.equal(0);
   });
 
+  describe('multiword', function() {
     beforeEach(() => {
       highlighter = shallow(
         <Highlighter multiword={true} search="">
@@ -69,6 +72,8 @@ describe('<Highlighter>', () => {
         </Highlighter>
       );
     });
+
+    it('matches', () => {
       matches = highlighter
         .setProps({search: 'nia cal'})
         .find('mark');


### PR DESCRIPTION
I created a **multiword highlighter** for my project where I need to match full sentences. The actual matching I do with a custom filterBy function using [string-similarity](https://www.npmjs.com/package/string-similarity).

```
<Highlighter multiword={true} search="match all words">
Do really all that superwords are matching?
</Highlighter>
```
Will generate: Do really `all` that super`words` are `match`ing?

And a preference to search from words **beginningOnly**:

```
<Highlighter multiword={true} beginningOnly={true} search="match all words">
Do really all that superwords match?
</Highlighter>
```
Will generate: Do really `all` that superwords are `match`ing?
