### PR TITLE
alwaysOpen prop

### DIFF
--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -33,6 +33,7 @@ class Typeahead extends React.Component {
       menuId,
       renderMenu,
       results,
+      alwaysOpen
     } = this.props;
 
     const inputProps = pick(this.props, [
@@ -101,8 +102,8 @@ class Typeahead extends React.Component {
         <Overlay
           {...overlayProps}
           container={bodyContainer ? document.body : this}
-          referenceElement={this._inputContainer}
-          show={isMenuShown}>
+          referenceElement={this._inputContainer ? this._inputContainer : alwaysOpen}
+          show={alwaysOpen ? true : isMenuShown}>
           {renderMenu(results, {...menuProps, id: menuId})}
         </Overlay>
         <div

--- a/src/containers/typeaheadContainer.js
+++ b/src/containers/typeaheadContainer.js
@@ -623,6 +623,10 @@ function typeaheadContainer(Typeahead) {
      * Allows selecting the hinted result by pressing enter.
      */
     selectHintOnEnter: PropTypes.bool,
+    /**
+     * Forces the Overlay to be always open, in order to simulate an on-page results list
+     */
+    alwaysOpen: PropTypes.bool
   };
 
   WrappedTypeahead.defaultProps = {


### PR DESCRIPTION
Introduces an `alwaysOpen` property to force the `<Overlay>` to render immediately and always show. This helps developers simulate an on-page results list with a little CSS trickery.