### PR TITLE
Vertically centered clear element for BS4

### DIFF
--- a/scss/Typeahead-bs4.scss
+++ b/scss/Typeahead-bs4.scss
@@ -44,6 +44,11 @@
       }
     }
   }
+  &-aux {
+    & .rbt-close {
+      margin-top: 0;
+    }
+  }
 }
 
 .input-group > .rbt {


### PR DESCRIPTION
**What issue does this pull request resolve?**

Clear component isn't vertically centered for BS4:
![selection_007](https://user-images.githubusercontent.com/11986226/53700641-1fbcd500-3dfd-11e9-8e62-d9fee1f4631a.png)

**What changes did you make?**

Cleared the top margin causing the alignment issue

**Is there anything that requires more attention while reviewing?**

N/A
