### PR TITLE
Fix target.className type error is not a string on SVG element

### DIFF
--- a/src/containers/typeaheadContainer.js
+++ b/src/containers/typeaheadContainer.js
@@ -412,6 +412,7 @@ function typeaheadContainer(Component) {
         while (target && target !== document.body) {
           if (
             target.className &&
+            typeof target.className === 'string' &&
             target.className.indexOf('rbt-menu') > -1
           ) {
             isBodyMenuClick = true;


### PR DESCRIPTION
**What changes did you make?**
Checking the type of `target.className`: on SVG element `target.className` is an object, not a string so `target.className.indexOf` will throw the error `target.className.indexOf is not a function`