### PR TITLE
Fix combination of open=false and highlightOnlyResult

### DIFF
--- a/src/containers/contextContainer.js
+++ b/src/containers/contextContainer.js
@@ -47,7 +47,7 @@ function contextContainer(Typeahead) {
 
       switch (e.keyCode) {
         case RETURN:
-          if (getIsOnlyResult(this.props)) {
+          if (getIsOnlyResult(this.props) && initialItem) {
             onAdd(initialItem);
           }
           break;

--- a/test/components/TypeaheadSpec.js
+++ b/test/components/TypeaheadSpec.js
@@ -645,6 +645,15 @@ describe('<Typeahead>', () => {
       expect(selected.length).to.equal(1);
     });
 
+    it('is compatible with `open=false`', () => {
+      typeahead.setProps({highlightOnlyResult: true, open: false});
+
+      change(typeahead, 'Alab');
+      focus(typeahead);
+
+      keyDown(typeahead, RETURN);
+    });
+
     it('does not highlight the only result when `allowNew=true`', () => {
       typeahead.setProps({
         allowNew: true,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request.

Before continuing, please read the guidelines:
https://github.com/ericgio/react-bootstrap-typeahead/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
#459

**What changes did you make?**
Prevent adding the initial item if it is not truthy

**Is there anything that requires more attention while reviewing?**
Perhaps it should actually add the only result even though the menu is hidden?
