### PR TITLE
Fix AsyncTypeahead example code

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -74,6 +74,7 @@ An enhanced version of the normal `Typeahead` component for use when performing 
       }));
   }}
   options={this.state.options}
+  labelKey={option => `${option.login}`}
 />
 ```
 


### PR DESCRIPTION
fix this error: 
One or more options does not have a valid label string. Check the `labelKey` prop to ensure that it matches the correct option key and provides a string for filtering and display.
