### PR TITLE
Pass through id to input so it can be used with a label

### DIFF
--- a/src/Typeahead.react.js
+++ b/src/Typeahead.react.js
@@ -49,6 +49,7 @@ class Typeahead extends React.Component {
       'renderToken',
       'selected',
       'text',
+      'id',
     ]);
 
     const overlayProps = pick(this.props, [

--- a/src/containers/inputContainer.js
+++ b/src/containers/inputContainer.js
@@ -28,6 +28,7 @@ function inputContainer(Input) {
         placeholder,
         renderToken,
         selected,
+        id,
       } = this.props;
 
       const {autoComplete, type} = this.props.inputProps;
@@ -44,6 +45,7 @@ function inputContainer(Input) {
         'aria-owns': isMenuShown ? menuId : undefined,
         autoComplete: autoComplete || 'nope',
         disabled,
+        id,
         inputRef,
         onBlur,
         onChange,


### PR DESCRIPTION
In https://github.com/ericgio/react-bootstrap-typeahead/blob/master/docs/Props.md#props it lists the `id` prop for the Typeahead component.

This is necessary for assistive technologies but also to allow selecting the input from a label a fairly core HTML behaviour.

Currently it doesn't work. This PR should fix that.