### PR TITLE
New property: groupBy

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -29,6 +29,7 @@ Name | Type | Default | Description
 -----|------|---------|------------
 `allowNew` | `boolean\|function` | `false` | Specifies whether or not arbitrary, user-defined options may be added to the result set. New entries will be included when the trimmed input is truthy and there is no exact match in the result set.<br><br>If a function is specified, allows for a callback to decide whether the new entry menu item should be included in the results list. The callback should return a boolean value:<br><br><pre>`(results: Array<Object\|string>, props: Object) => boolean`</pre>
 `filterBy` | `Array<string>\|function` | | See full documentation in the [Filtering section](Filtering.md#filterby-arraystring--function).
+`groupBy` | `string\|function` | | See full documentation in the [Grouping section](Grouping.md).
 `labelKey` | `string\|function` | | See full documentation in the [Rendering section](Rendering.md#labelkey-string--function).
 `renderInput` | `function` | | See full documentation in the [Rendering section](Rendering.md#renderinputinputprops-object-state-object).
 `renderMenu` | `function` | | See full documentation in the [Rendering section](Rendering.md#rendermenuresults-arrayobjectstring-menuprops-object-state-object).

--- a/docs/Filtering.md
+++ b/docs/Filtering.md
@@ -44,4 +44,4 @@ You can also pass your own callback to take complete control over how the filter
 />
 ```
 
-[Next: Rendering](Rendering.md)
+[Next: Grouping](Grouping.md)

--- a/docs/Grouping.md
+++ b/docs/Grouping.md
@@ -1,0 +1,71 @@
+# Grouping
+
+By default, the component will render all options in the same level. You can group the options by suppling `groupBy`:
+
+### `groupBy: string|Function`
+
+#### `string:`
+
+If this property is a string, it must be a propery present in each option.
+
+```jsx
+const options = [
+  { name: 'Alabama', region: 'South' },
+  { name: 'Alaska', region: 'West' },
+  { name: 'Arizona', region: 'West' },
+  { name: 'Arkansas', region: 'South' },
+  ...
+];
+
+<Typeahead
+  ...
+  options={options}
+  labelBy="name"
+  groupBy="region"
+/>
+```
+
+#### `Function`
+
+`groupBy` also supports a function for custom grouping:
+
+```jsx
+const options = [
+  { name: 'Alabama', population: 4780127 },
+  { name: 'Alaska', population: 710249 },
+  { name: 'Arizona', population: 6392307 },
+  { name: 'Arkansas', population: 2915958 },
+  ...
+];
+
+const groupFn = (options) => {
+  const sm = [];
+  const md = [];
+  const lg = [];
+
+  options.forEach(option => {
+    if(option.population < 1000000) {
+      sm.push(option);
+    } else if (option.population < 10000000) {
+      md.push(option);
+    } else {
+      lg.push(option);
+    }
+  });
+
+  return {
+    'Small (< 1 mi)': sm,
+    'Medium (< 10 mi)': md,
+    'Large (+10 mi)': lg
+  };
+}
+
+<Typeahead
+  ...
+  options={options}
+  labelBy="name"
+  groupBy={groupFn}
+/>
+```
+
+[Next: Rendering](Rendering.md)

--- a/docs/Props.md
+++ b/docs/Props.md
@@ -18,6 +18,7 @@ emptyLabel | node | 'No matches found.' | Message displayed in the menu when the
 filterBy | function or array | `[]` | Either an array of fields in `option` to search, or a custom filtering callback. See the [Filtering](https://github.com/ericgio/react-bootstrap-typeahead/blob/master/docs/Filtering.md#filterby) page for more info.
 flip | boolean | false | Whether or not to automatically adjust the position of the menu when it reaches the viewport boundaries.
 highlightOnlyResult | boolean | false | Highlights the menu item if there is only one result and allows selecting that item by hitting enter. Does not work with `allowNew`.
+groupBy | function or string | |Specify which option key to use for grouping, or a custom callback function. See the [Grouping](https://github.com/ericgio/react-bootstrap-typeahead/blob/master/docs/Grouping.md#filterby) page for more info.
 id `required` | string or number | | An html id attribute, required for assistive technologies such as screen readers.
 ignoreDiacritics | boolean | true | Whether the filter should ignore accents and other diacritical marks.
 inputProps | object | {} | Props to be applied directly to the input. `onBlur`, `onChange`, `onFocus`, and `onKeyDown` are ignored.

--- a/example/src/examples/GroupByExample.react.js
+++ b/example/src/examples/GroupByExample.react.js
@@ -1,0 +1,28 @@
+/* eslint-disable import/no-extraneous-dependencies,import/no-unresolved */
+
+import React, { Fragment, useState } from 'react';
+import { Typeahead } from 'react-bootstrap-typeahead';
+
+import options from '../data';
+
+/* example-start */
+const GroupByExample = () => {
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <Fragment>
+      <Typeahead
+        id="groupby-typeahead-example"
+        labelKey="name"
+        groupBy="region"
+        onChange={setSelected}
+        options={options}
+        placeholder="Choose a state..."
+        selected={selected}
+      />
+    </Fragment>
+  );
+};
+/* example-end */
+
+export default GroupByExample;

--- a/example/src/sections/RenderingSection.react.js
+++ b/example/src/sections/RenderingSection.react.js
@@ -1,10 +1,12 @@
 import React from 'react';
 
 import LabelKeyExample from '../examples/LabelKeyExample.react';
+import GroupByExample from '../examples/GroupByExample.react';
 import RenderingExample from '../examples/RenderingExample.react';
 
 /* eslint-disable import/no-unresolved */
 import LabelKeyExampleCode from '!raw-loader!../examples/LabelKeyExample.react';
+import GroupByExampleCode from '!raw-loader!../examples/GroupByExample.react';
 import RenderingExampleCode from '!raw-loader!../examples/RenderingExample.react';
 /* eslint-enable import/no-unresolved */
 
@@ -29,6 +31,14 @@ const RenderingSection = (props) => (
     </Markdown>
     <ExampleSection code={LabelKeyExampleCode}>
       <LabelKeyExample />
+    </ExampleSection>
+    <Title>GroupBy</Title>
+    <Markdown>
+      The `groupBy` prop accepts a callback allowing you to transform your data
+      and return a grouped object where the object keys are the groups label.
+    </Markdown>
+    <ExampleSection code={GroupByExampleCode}>
+      <GroupByExample />
     </ExampleSection>
   </Section>
 );

--- a/src/__tests__/components/TypeaheadMenu.test.js
+++ b/src/__tests__/components/TypeaheadMenu.test.js
@@ -2,6 +2,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 
 import MenuItem, { BaseMenuItem } from '../../components/MenuItem.react';
+import Menu from '../../components/Menu.react';
 import TypeaheadMenu from '../../components/TypeaheadMenu.react';
 
 import options from '../data';
@@ -23,7 +24,7 @@ describe('<TypeaheadMenu>', () => {
         labelKey="name"
         options={options}
         text=""
-      />
+      />,
     );
   });
 
@@ -44,7 +45,12 @@ describe('<TypeaheadMenu>', () => {
 
   test('renders disabled menu items', () => {
     menu.setProps({ options: options.map((o) => ({ ...o, disabled: true })) });
-    expect(menu.find(MenuItem).first().prop('disabled')).toBe(true);
+    expect(
+      menu
+        .find(MenuItem)
+        .first()
+        .prop('disabled'),
+    ).toBe(true);
   });
 
   test('renders an empty state when there are no results', () => {
@@ -83,6 +89,23 @@ describe('<TypeaheadMenu>', () => {
     test('does not show a paginator when there are no results', () => {
       menu.setProps({ options: [] });
       expect(getPaginator(menu).length).toBe(0);
+    });
+  });
+
+  describe('groupBy property', () => {
+    test('renders grouped by option key', () => {
+      const headers = menu.setProps({ groupBy: 'region' }).find(Menu.Header);
+      expect(headers.length).toBe(4);
+    });
+
+    test('renders grouped by function', () => {
+      const fn = ([option1, ...rest]) => ({
+        group1: [option1],
+        otherGroup: rest,
+      });
+
+      const headers = menu.setProps({ groupBy: fn }).find(Menu.Header);
+      expect(headers.length).toBe(2);
     });
   });
 });

--- a/src/__tests__/utils/defaultGroupBy.test.js
+++ b/src/__tests__/utils/defaultGroupBy.test.js
@@ -1,0 +1,16 @@
+import defaultGroupBy from '../../utils/defaultGroupBy';
+import states from '../data';
+
+describe('defaultGroupBy', () => {
+  let options;
+
+  beforeEach(() => {
+    options = states;
+  });
+
+  test('filters an array of objects', () => {
+    const results = defaultGroupBy('region')(options);
+    const groups = Object.keys(results);
+    expect(groups).toEqual(['South', 'West', 'Northeast', 'Midwest']);
+  });
+});

--- a/src/__tests__/utils/getGroupByFunction.test.js
+++ b/src/__tests__/utils/getGroupByFunction.test.js
@@ -1,0 +1,23 @@
+import getGroupByFunction from '../../utils/getGroupByFunction';
+import defaultGroupBy from '../../utils/defaultGroupBy';
+
+jest.mock('../../utils/defaultGroupBy');
+
+describe('getGroupByFunction', () => {
+  test('handles undefined', () => {
+    expect(getGroupByFunction(undefined)).toBeFalsy();
+  });
+
+  test('handles function', () => {
+    const fn = () => {};
+    expect(getGroupByFunction(fn)).toBe(fn);
+  });
+
+  test('handles string', () => {
+    const fn = () => {};
+    defaultGroupBy.mockReturnValue(fn);
+
+    expect(getGroupByFunction('str')).toBe(fn);
+    expect(defaultGroupBy).toBeCalledWith('str');
+  });
+});

--- a/src/components/Typeahead.react.js
+++ b/src/components/Typeahead.react.js
@@ -18,8 +18,19 @@ import TypeaheadInputMulti from './TypeaheadInputMulti.react';
 import TypeaheadInputSingle from './TypeaheadInputSingle.react';
 import TypeaheadMenu from './TypeaheadMenu.react';
 
-import { getOptionLabel, isFunction, isSizeLarge, pick, preventInputBlur } from '../utils';
-import { checkPropType, deprecated, inputPropsType, sizeType } from '../propTypes';
+import {
+  getOptionLabel,
+  isFunction,
+  isSizeLarge,
+  pick,
+  preventInputBlur,
+} from '../utils';
+import {
+  checkPropType,
+  deprecated,
+  inputPropsType,
+  sizeType,
+} from '../propTypes';
 
 import type { TypeaheadMenuProps } from './TypeaheadMenu.react';
 import type {
@@ -34,22 +45,23 @@ import type {
   TypeaheadManagerProps,
 } from '../types';
 
-type Props = TypeaheadProps & TypeaheadMenuProps & {
-  bsSize?: Size,
-  className?: string,
-  clearButton: boolean,
-  disabled?: boolean,
-  instanceRef: RefCallback<any>,
-  inputProps: Object,
-  isInvalid: boolean,
-  isLoading: boolean,
-  isValid: boolean,
-  renderInput: (InputProps, TypeaheadManagerProps) => Node,
-  renderMenu: (Option[], TypeaheadMenuProps, TypeaheadProps) => Node,
-  renderToken: (Option, Object & InputProps, number) => Node,
-  size?: Size,
-  style?: Style,
-};
+type Props = TypeaheadProps &
+  TypeaheadMenuProps & {
+    bsSize?: Size,
+    className?: string,
+    clearButton: boolean,
+    disabled?: boolean,
+    instanceRef: RefCallback<any>,
+    inputProps: Object,
+    isInvalid: boolean,
+    isLoading: boolean,
+    isValid: boolean,
+    renderInput: (InputProps, TypeaheadManagerProps) => Node,
+    renderMenu: (Option[], TypeaheadMenuProps, TypeaheadProps) => Node,
+    renderToken: (Option, Object & InputProps, number) => Node,
+    size?: Size,
+    style?: Style,
+  };
 
 const propTypes = {
   /**
@@ -104,7 +116,7 @@ const defaultProps = {
   renderMenu: (
     results: Option[],
     menuProps: TypeaheadMenuProps,
-    props: TypeaheadManagerProps
+    props: TypeaheadManagerProps,
   ) => (
     <TypeaheadMenu
       {...menuProps}
@@ -116,26 +128,22 @@ const defaultProps = {
   renderToken: (
     option: Option,
     props: TypeaheadManagerProps & InputProps,
-    idx: number
+    idx: number,
   ) => (
     <Token
       disabled={props.disabled}
       key={idx}
       onRemove={props.onRemove}
       option={option}
-      tabIndex={props.tabIndex}>
+      tabIndex={props.tabIndex}
+    >
       {getOptionLabel(option, props.labelKey)}
     </Token>
   ),
 };
 
 function getOverlayProps(props: Props) {
-  return pick(props, [
-    'align',
-    'dropup',
-    'flip',
-    'positionFixed',
-  ]);
+  return pick(props, ['align', 'dropup', 'flip', 'positionFixed']);
 }
 
 class TypeaheadComponent extends React.Component<Props> {
@@ -163,7 +171,8 @@ class TypeaheadComponent extends React.Component<Props> {
           return (
             <RootCloseWrapper
               disabled={open || !isMenuShown}
-              onRootClose={hideMenu}>
+              onRootClose={hideMenu}
+            >
               <div
                 className={cx('rbt', { 'has-aux': !!auxContent }, className)}
                 style={{
@@ -171,20 +180,23 @@ class TypeaheadComponent extends React.Component<Props> {
                   outline: 'none',
                   position: 'relative',
                 }}
-                tabIndex={-1}>
-                {this._renderInput({
-                  ...getInputProps(this.props.inputProps),
-                  ref: this.referenceElementRef,
-                }, props)}
+                tabIndex={-1}
+              >
+                {this._renderInput(
+                  {
+                    ...getInputProps(this.props.inputProps),
+                    ref: this.referenceElementRef,
+                  },
+                  props,
+                )}
                 <Overlay
                   {...getOverlayProps(this.props)}
                   isMenuShown={isMenuShown}
-                  referenceElement={this._referenceElement}>
-                  {(menuProps: MenuProps) => this._renderMenu(
-                    results,
-                    menuProps,
-                    props
-                  )}
+                  referenceElement={this._referenceElement}
+                >
+                  {(menuProps: MenuProps) =>
+                    this._renderMenu(results, menuProps, props)
+                  }
                 </Overlay>
                 {auxContent}
                 {isFunction(children) ? children(props) : children}
@@ -203,7 +215,7 @@ class TypeaheadComponent extends React.Component<Props> {
     // $FlowFixMe: `findDOMNode` could return Text or an Element.
     this._referenceElement = findDOMNode(element);
     /* eslint-enable react/no-find-dom-node */
-  }
+  };
 
   _renderInput = (inputProps: InputProps, props: TypeaheadManagerProps) => {
     const {
@@ -234,24 +246,23 @@ class TypeaheadComponent extends React.Component<Props> {
     const { labelKey, onRemove, selected } = props;
 
     return (
-      <TypeaheadInputMulti
-        {...commonProps}
-        selected={selected}>
-        {selected.map((option, idx) => (
-          renderToken(option, { ...commonProps, labelKey, onRemove }, idx)
-        ))}
+      <TypeaheadInputMulti {...commonProps} selected={selected}>
+        {selected.map((option, idx) =>
+          renderToken(option, { ...commonProps, labelKey, onRemove }, idx),
+        )}
       </TypeaheadInputMulti>
     );
-  }
+  };
 
   _renderMenu = (
     results: Option[],
     menuProps: MenuProps,
-    props: TypeaheadManagerProps
+    props: TypeaheadManagerProps,
   ) => {
     const {
       emptyLabel,
       id,
+      groupBy,
       maxHeight,
       newSelectionPrefix,
       paginationText,
@@ -260,16 +271,21 @@ class TypeaheadComponent extends React.Component<Props> {
       renderMenuItemChildren,
     } = this.props;
 
-    return renderMenu(results, {
-      ...menuProps,
-      emptyLabel,
-      id,
-      maxHeight,
-      newSelectionPrefix,
-      paginationText,
-      renderMenuItemChildren,
-    }, props);
-  }
+    return renderMenu(
+      results,
+      {
+        ...menuProps,
+        emptyLabel,
+        groupBy,
+        id,
+        maxHeight,
+        newSelectionPrefix,
+        paginationText,
+        renderMenuItemChildren,
+      },
+      props,
+    );
+  };
 
   _renderAux = ({ onClear, selected }: TypeaheadManagerProps) => {
     const { bsSize, clearButton, disabled, isLoading, size } = this.props;
@@ -279,7 +295,7 @@ class TypeaheadComponent extends React.Component<Props> {
     if (isLoading) {
       content = <Loader size={bsSize || size} />;
     } else if (clearButton && !disabled && selected.length) {
-      content =
+      content = (
         <ClearButton
           size={bsSize || size}
           onClick={onClear}
@@ -288,20 +304,22 @@ class TypeaheadComponent extends React.Component<Props> {
             e.stopPropagation();
           }}
           onMouseDown={preventInputBlur}
-        />;
+        />
+      );
     }
 
-    return content ?
+    return content ? (
       <div
         className={cx('rbt-aux', {
           'rbt-aux-lg': isSizeLarge(bsSize),
-        })}>
+        })}
+      >
         {content}
-      </div> :
-      null;
-  }
+      </div>
+    ) : null;
+  };
 }
 
 export default forwardRef<* & Props, ElementRef<typeof Typeahead>>(
-  (props, ref) => <TypeaheadComponent {...props} instanceRef={ref} />
+  (props, ref) => <TypeaheadComponent {...props} instanceRef={ref} />,
 );

--- a/src/types.js
+++ b/src/types.js
@@ -11,7 +11,10 @@ export type Id = number | string;
 export type KeyboardEventHandler<T> = (SyntheticKeyboardEvent<T>) => void;
 export type Option = string | { [string]: any };
 export type OptionHandler = (Option) => void;
-export type LabelKey = string | (Option) => string;
+export type GroupedOptions = { [key: string]: Option[] };
+export type GroupByFunction = (options: Option[]) => GroupedOptions;
+export type GroupBy = string | GroupByFunction;
+export type LabelKey = string | ((Option) => string);
 export type ReferenceElement = HTMLElement;
 export type Size = $Values<typeof SIZE>;
 export type Style = { [string]: any };
@@ -59,14 +62,15 @@ export type MenuProps = {
 };
 
 export type TypeaheadProps = {
-  allowNew: boolean | (Option[], TypeaheadPropsAndState) => boolean,
+  allowNew: boolean | ((Option[], TypeaheadPropsAndState) => boolean),
   autoFocus: boolean,
   caseSensitive: boolean,
   children: Function,
   defaultInputValue: string,
   defaultOpen: boolean,
   defaultSelected: Option[],
-  filterBy: string[] | (Option, TypeaheadPropsAndState) => void,
+  filterBy: string[] | ((Option, TypeaheadPropsAndState) => void),
+  groupBy: GroupBy<T>,
   highlightOnlyResult: boolean,
   id?: Id,
   ignoreDiacritics: boolean,

--- a/src/utils/defaultGroupBy.js
+++ b/src/utils/defaultGroupBy.js
@@ -1,0 +1,21 @@
+// @flow
+
+import type { GroupedOptions, Option } from '../types';
+
+export default function defaultGroupBy(
+  groupKey: typeof Option
+): (options: Option[]) => GroupedOptions {
+  return function groupBy(options) {
+    return options.reduce((grouped: GroupedOptions, option: Option) => {
+      const group = option[groupKey];
+      const copy = { ...grouped };
+
+      if (!copy[group]) {
+        copy[group] = [];
+      }
+
+      copy[group].push(option);
+      return copy;
+    }, {});
+  };
+}

--- a/src/utils/getGroupByFunction.js
+++ b/src/utils/getGroupByFunction.js
@@ -1,0 +1,14 @@
+// @flow
+
+import type { GroupBy } from '../types';
+import defaultGroupBy from './defaultGroupBy';
+
+export default function getGroupByFunction(
+  groupKey: GroupBy
+): (options: Option[]) => GroupedOptions | undefined {
+  if (groupKey === undefined || typeof groupKey === 'function') {
+    return groupKey;
+  }
+
+  return defaultGroupBy(groupKey);
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,7 @@ export addCustomOption from './addCustomOption';
 export defaultFilterBy from './defaultFilterBy';
 export getDisplayName from './getDisplayName';
 export getHintText from './getHintText';
+export getGroupByFunction from './getGroupByFunction';
 export getInputProps from './getInputProps';
 export getInputText from './getInputText';
 export getIsOnlyResult from './getIsOnlyResult';


### PR DESCRIPTION
**What issue does this pull request resolve?**
Adds a new property for grouping: `groupBy`. It accepts a string (typeof Option) or a callback function. More info on #539.

**What changes did you make?**
* A new property to Typeahead, TypeaheadMenu.
* Unit tests
* Documentation.

**Is there anything that requires more attention while reviewing?**
Possible typos in the documentation.

Also, I'm using [Prettier](https://prettier.io/). I created a config file that tries to match the most common style in this project, but I didn't push the file (let me know if I should). It also means that there are some changes that seems unrelated to the feature.
