### PR TITLE
Make the style rule for multi-input more specific

### DIFF
--- a/styles/Typeahead-bs4.scss
+++ b/styles/Typeahead-bs4.scss
@@ -35,7 +35,7 @@ $placeholder-color: #6c757d;
       }
 
       // Safari and Chrome
-      &::-webkit-input-placeholder  {
+      &::-webkit-input-placeholder {
         color: $placeholder-color;
       }
     }
@@ -43,7 +43,8 @@ $placeholder-color: #6c757d;
     // Override height in main CSS file :/
     & .rbt-input-main,
     &.form-control-lg .rbt-input-main,
-    &.form-control-sm .rbt-input-main {
+    &.form-control-sm .rbt-input-main,
+    &.form-control {
       height: auto;
     }
   }

--- a/styles/Typeahead.scss
+++ b/styles/Typeahead.scss
@@ -29,7 +29,10 @@ $placeholder-color: #999;
     cursor: text;
     overflow: hidden;
     position: relative;
-    height: auto;
+
+    &.form-control {
+      height: auto;
+    }
 
     // Apply Bootstrap focus styles
     &.focus {
@@ -58,7 +61,7 @@ $placeholder-color: #999;
       }
 
       // Safari and Chrome
-      &::-webkit-input-placeholder  {
+      &::-webkit-input-placeholder {
         color: $placeholder-color;
       }
     }


### PR DESCRIPTION
As per our conversation in https://github.com/ericgio/react-bootstrap-typeahead/issues/542.