### PR TITLE
Update AsyncExample.js

### DIFF
--- a/example/src/examples/AsyncExample.js
+++ b/example/src/examples/AsyncExample.js
@@ -35,6 +35,7 @@ const AsyncExample = () => {
 
   return (
     <AsyncTypeahead
+      filterBy={() => true}
       id="async-example"
       isLoading={isLoading}
       labelKey="login"


### PR DESCRIPTION
This PR adds `filterBy={() => true}` to the `AyncExample`.

It's an issue when the server is filtering by multiple fields (such as name, family-name, email, tags, etc..)
and then, if the client `labelKey` is only by `name` (for example), no result will be shown.
Ones can set the `labelKey` to have all the fields inside or create `filterBy` array on all the fields (which is not always possible, and sometimes even the backend doesn't return all the fields to the client).

Also, when filtering server-side, it's a waste to filter again in client-side all results.

IMHO It's important thing to be in the example, as in our case, took us few hours to find this out and we unfortunately first tried to set the `labelKey` to `${name} ${email}` and then override both `renderInput`, `renderToken` and `renderMenuItemChildren` to show only the `name` field...