### PR TITLE
Floating labels

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <link rel="icon" href="public/favicon.ico">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">    <link rel="stylesheet" href="public/examples.css">
+    <link rel="stylesheet" href="public/examples.css">
     <link rel="stylesheet" href="public/prism.css">
     <title>React Bootstrap Typeahead Example</title>
   </head>

--- a/example/index.html
+++ b/example/index.html
@@ -3,8 +3,7 @@
   <head>
     <meta charset="utf-8">
     <link rel="icon" href="public/favicon.ico">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-    <link rel="stylesheet" href="public/examples.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">    <link rel="stylesheet" href="public/examples.css">
     <link rel="stylesheet" href="public/prism.css">
     <title>React Bootstrap Typeahead Example</title>
   </head>

--- a/example/src/examples/FloatingLabelExample.js
+++ b/example/src/examples/FloatingLabelExample.js
@@ -1,0 +1,69 @@
+/* eslint-disable import/no-extraneous-dependencies,import/no-unresolved,linebreak-style */
+
+import React, { Fragment, useState } from 'react';
+import { Form } from 'react-bootstrap';
+import { Typeahead } from 'react-bootstrap-typeahead';
+
+import options from '../data';
+
+/* example-start */
+const BasicExample = () => {
+  const [singleSelections, setSingleSelections] = useState([]);
+  const [multiSelections, setMultiSelections] = useState([]);
+
+  return (
+    <Fragment>
+      <Form.Group>
+        <Form.Label>Single Selection</Form.Label>
+        <Typeahead
+          id="basic-typeahead-single"
+          labelKey="name"
+          onChange={setSingleSelections}
+          options={options}
+          placeholder="Choose a state..."
+          selected={singleSelections}
+        />
+      </Form.Group>
+      <Form.Group style={{ marginTop: '20px' }}>
+        <Form.Label>Multiple Selections</Form.Label>
+        <Typeahead
+          id="basic-typeahead-multiple"
+          labelKey="name"
+          multiple
+          onChange={setMultiSelections}
+          options={options}
+          placeholder="Choose several states..."
+          selected={multiSelections}
+        />
+      </Form.Group>
+      <Form.Group style={{ marginTop: '20px' }}>
+        <Form.Label>Floating labels</Form.Label>
+          <div className={"my-5"}>
+              <h1>Floating labels</h1>
+              <Typeahead
+                  id={"floatingExample"}
+                  inputProps={
+                      {id:"floatingExampleInput",
+                          useFloatingLabel:true,
+                          floatingLabelText:"Floating label"}
+                  }
+                  options={["Paris", "London", "New York"]}
+
+              />
+              <Typeahead
+                  id={"floatingMultiExample"}
+                  inputProps={
+                      {id:"floatingMultiExampleInput",
+                          useFloatingLabel:true,
+                          floatingLabelText:"Floating label"}
+                  }
+                  multiple={true}
+                  options={["Paris", "London", "New York"]}
+              />
+          </div>
+    </Fragment>
+  );
+};
+/* example-end */
+
+export default BasicExample;

--- a/example/src/examples/FloatingLabelExample.js
+++ b/example/src/examples/FloatingLabelExample.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies,import/no-unresolved,linebreak-style */
+/* eslint-disable import/no-extraneous-dependencies,import/no-unresolved,linebreak-style,indent,react/jsx-indent */
 
 import React, { Fragment, useState } from 'react';
 import { Form } from 'react-bootstrap';
@@ -7,63 +7,52 @@ import { Typeahead } from 'react-bootstrap-typeahead';
 import options from '../data';
 
 /* example-start */
-const BasicExample = () => {
-  const [singleSelections, setSingleSelections] = useState([]);
-  const [multiSelections, setMultiSelections] = useState([]);
+const FloatingLabelExample = () => {
+    const [singleFloatingSelections, setSingleFloatingSelections] = useState([]);
+    const [multiFloatingSelections, setMultiFloatingSelections] = useState([]);
 
-  return (
-    <Fragment>
-      <Form.Group>
-        <Form.Label>Single Selection</Form.Label>
-        <Typeahead
-          id="basic-typeahead-single"
-          labelKey="name"
-          onChange={setSingleSelections}
-          options={options}
-          placeholder="Choose a state..."
-          selected={singleSelections}
-        />
-      </Form.Group>
-      <Form.Group style={{ marginTop: '20px' }}>
-        <Form.Label>Multiple Selections</Form.Label>
-        <Typeahead
-          id="basic-typeahead-multiple"
-          labelKey="name"
-          multiple
-          onChange={setMultiSelections}
-          options={options}
-          placeholder="Choose several states..."
-          selected={multiSelections}
-        />
-      </Form.Group>
-      <Form.Group style={{ marginTop: '20px' }}>
-        <Form.Label>Floating labels</Form.Label>
-          <div className={"my-5"}>
-              <h1>Floating labels</h1>
-              <Typeahead
-                  id={"floatingExample"}
+    return (
+        <Fragment>
+            <Form.Group style={{ marginTop: '20px' }}>
+                <Form.Label>Floating labels (single)</Form.Label>
+                <Typeahead
+                  id="basic-typeahead-single-floating-label"
                   inputProps={
-                      {id:"floatingExampleInput",
-                          useFloatingLabel:true,
-                          floatingLabelText:"Floating label"}
-                  }
-                  options={["Paris", "London", "New York"]}
-
-              />
-              <Typeahead
-                  id={"floatingMultiExample"}
+                        {
+                            floatingLabelText: 'Floating label',
+                            id: 'basic-typeahead-single-floating-label-input',
+                            useFloatingLabel: true,
+                        }
+                    }
+                  labelKey="name"
+                  options={options}
+                  onChange={setSingleFloatingSelections}
+                  placeholder="Choose a state..."
+                  selected={singleFloatingSelections}
+                />
+            </Form.Group>
+            <Form.Group style={{ marginTop: '20px' }}>
+                <Form.Label>Floating labels (multiple)</Form.Label>
+                <Typeahead
+                  id="basic-typeahead-multiple-floating-label"
                   inputProps={
-                      {id:"floatingMultiExampleInput",
-                          useFloatingLabel:true,
-                          floatingLabelText:"Floating label"}
-                  }
-                  multiple={true}
-                  options={["Paris", "London", "New York"]}
-              />
-          </div>
-    </Fragment>
-  );
+                        {
+                            floatingLabelText: 'Floating label',
+                            id: 'basic-typeahead-multiple-floating-label-input',
+                            useFloatingLabel: true,
+                        }
+                    }
+                  multiple
+                  labelKey="name"
+                  options={options}
+                  onChange={setMultiFloatingSelections}
+                  placeholder="Choose several states..."
+                  selected={multiFloatingSelections}
+                />
+            </Form.Group>
+        </Fragment>
+);
 };
 /* example-end */
 
-export default BasicExample;
+export default FloatingLabelExample;

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -10,6 +10,7 @@ import CustomSelectionsSection from './sections/CustomSelectionsSection';
 import FilteringSection from './sections/FilteringSection';
 import PublicMethodsSection from './sections/PublicMethodsSection';
 import RenderingSection from './sections/RenderingSection';
+import FloatingLabelSection from "./sections/FloatingLabelSection";
 
 import '../../styles/Typeahead.scss';
 
@@ -17,6 +18,7 @@ ReactDOM.render(
   <React.StrictMode>
     <Page>
       <BasicSection />
+        <FloatingLabelSection/>
       <BehaviorsSection />
       <RenderingSection />
       <FilteringSection />

--- a/example/src/sections/FloatingLabelSection.js
+++ b/example/src/sections/FloatingLabelSection.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import BasicExample from '../examples/BasicExample';
+/* eslint-disable import/no-unresolved, import/extensions */
+import BasicExampleCode from '!raw-loader!../examples/BasicExample';
+/* eslint-enable import/no-unresolved, import/extensions */
+
+import ExampleSection from '../components/ExampleSection';
+import Markdown from '../components/Markdown';
+import Section from '../components/Section';
+
+const BasicSection = (props) => (
+  <Section title={props.title}>
+    <Markdown>
+      The typeahead allows single-selection by default. Setting the `multiple`
+      prop turns the component into a tokenizer, allowing multiple selections.
+    </Markdown>
+    <ExampleSection code={BasicExampleCode}>
+      <BasicExample />
+    </ExampleSection>
+  </Section>
+);
+
+BasicSection.defaultProps = {
+  title: 'Basic Example',
+};
+
+export default BasicSection;

--- a/example/src/sections/FloatingLabelSection.js
+++ b/example/src/sections/FloatingLabelSection.js
@@ -1,28 +1,27 @@
 import React from 'react';
 
-import BasicExample from '../examples/BasicExample';
+import FloatingLabelExample from '../examples/FloatingLabelExample';
 /* eslint-disable import/no-unresolved, import/extensions */
-import BasicExampleCode from '!raw-loader!../examples/BasicExample';
+import FloatingLabelCode from '!raw-loader!../examples/FloatingLabelExample';
 /* eslint-enable import/no-unresolved, import/extensions */
 
 import ExampleSection from '../components/ExampleSection';
 import Markdown from '../components/Markdown';
 import Section from '../components/Section';
 
-const BasicSection = (props) => (
+const FloatingLabelSection = (props) => (
   <Section title={props.title}>
     <Markdown>
-      The typeahead allows single-selection by default. Setting the `multiple`
-      prop turns the component into a tokenizer, allowing multiple selections.
+      When using Bootstrap 5, pass a unique `id`, `floatingLabelText`, `useFloatingLabel: true` in the `inputProps` to enable floating labels. Bootstrap also requires a `placeholder`, `useFloatingLabel` will be used as a fallback if one is not provided and vice versa. If neither is provided the label will not react to focussing.
     </Markdown>
-    <ExampleSection code={BasicExampleCode}>
-      <BasicExample />
+    <ExampleSection code={FloatingLabelCode}>
+      <FloatingLabelExample />
     </ExampleSection>
   </Section>
 );
 
-BasicSection.defaultProps = {
-  title: 'Basic Example',
+FloatingLabelSection.defaultProps = {
+  title: 'Floating Labels Example',
 };
 
-export default BasicSection;
+export default FloatingLabelSection;

--- a/example/src/util/getIdFromTitle.js
+++ b/example/src/util/getIdFromTitle.js
@@ -1,1 +1,1 @@
-export default (title) => title.toLocaleLowerCase().split(' ').join('-');
+export default (title) => title?.toLocaleLowerCase().split(' ').join('-');

--- a/src/components/TypeaheadInputMulti.js
+++ b/src/components/TypeaheadInputMulti.js
@@ -57,7 +57,7 @@ class TypeaheadInputMulti extends React.Component<Props> {
         <div className="rbt-input-wrapper" ref={this.wrapperRef}>
           {children}
           <Hint shouldSelect={shouldSelectHint}>
-            <div className={useFloatingLabel ? "form-floating" : ""}>
+            <div className={`w-100 ${useFloatingLabel ? "form-floating" : ""}`}>
               <Input
                 {...props}
                 className={`${useFloatingLabel?"form-control" : ""} inputClassName`}

--- a/src/components/TypeaheadInputMulti.js
+++ b/src/components/TypeaheadInputMulti.js
@@ -40,36 +40,44 @@ class TypeaheadInputMulti extends React.Component<Props> {
       shouldSelectHint,
       ...props
     } = this.props;
-
+    const useFloatingLabel = props.useFloatingLabel;
+    const floatingLabelText = props.floatingLabelText || props.placeholder || null;
+    props.placeholder = props.placeholder || props.floatingLabelText || null;
+    delete props.useFloatingLabel;
+    delete props.floatingLabelText;
     return (
       <div
-        className={cx('rbt-input-multi', className)}
+        className={cx('rbt-input-multi', className, useFloatingLabel && "rbt-multi-input-floating-label")}
         disabled={props.disabled}
         onClick={this._handleContainerClickOrFocus}
         onFocus={this._handleContainerClickOrFocus}
         ref={referenceElementRef}
-        tabIndex={-1}>
+        tabIndex={-1}
+        style={useFloatingLabel ? {padding: 0} : null}>
         <div className="rbt-input-wrapper" ref={this.wrapperRef}>
           {children}
           <Hint shouldSelect={shouldSelectHint}>
-            <Input
-              {...props}
-              className={inputClassName}
-              onClick={this._handleClick}
-              onKeyDown={this._handleKeyDown}
-              placeholder={selected.length ? '' : placeholder}
-              ref={this.getInputRef}
-              style={{
-                backgroundColor: 'transparent',
-                border: 0,
-                boxShadow: 'none',
-                cursor: 'inherit',
-                outline: 'none',
-                padding: 0,
-                width: '100%',
-                zIndex: 1,
-              }}
+            <div className={useFloatingLabel ? "form-floating" : ""}>
+              <Input
+                {...props}
+                className={`${useFloatingLabel?"form-control" : ""} inputClassName`}
+                onClick={this._handleClick}
+                onKeyDown={this._handleKeyDown}
+                placeholder={useFloatingLabel ? props.placeholder : (selected.length ? '' : props.placeholder)}
+                ref={this.getInputRef}
+                style={{
+                  backgroundColor: 'transparent',
+                  border: 0,
+                  boxShadow: 'none',
+                  cursor: 'inherit',
+                  outline: 'none',
+                  padding: useFloatingLabel ? null : 0,
+                  width: '100%',
+                  zIndex: 1,
+                }}
             />
+              {useFloatingLabel && <label htmlFor={props.id}>{floatingLabelText}</label>}
+            </div>
           </Hint>
         </div>
       </div>

--- a/src/components/TypeaheadInputSingle.js
+++ b/src/components/TypeaheadInputSingle.js
@@ -2,32 +2,41 @@
 
 import React from 'react';
 
-import Hint, { type ShouldSelect } from './Hint';
+import Hint, {type ShouldSelect} from './Hint';
 import Input from './Input';
 
 import withClassNames from '../behaviors/classNames';
 
-import type { RefCallback, ReferenceElement } from '../types';
+import type {RefCallback, ReferenceElement} from '../types';
 
 type Props = {
-  inputRef: RefCallback<HTMLInputElement>,
-  referenceElementRef: RefCallback<ReferenceElement>,
-  shouldSelectHint?: ShouldSelect,
+    inputRef: RefCallback<HTMLInputElement>,
+    referenceElementRef: RefCallback<ReferenceElement>,
+    shouldSelectHint?: ShouldSelect,
 };
 
 export default withClassNames(({
-  inputRef,
-  referenceElementRef,
-  shouldSelectHint,
-  ...props
-}: Props) => (
-  <Hint shouldSelect={shouldSelectHint}>
-    <Input
-      {...props}
-      ref={(node) => {
-        inputRef(node);
-        referenceElementRef(node);
-      }}
-    />
-  </Hint>
-));
+                                   inputRef,
+                                   referenceElementRef,
+                                   shouldSelectHint,
+                                   ...props
+                               }: Props) => {
+    const useFloatingLabel = props.useFloatingLabel;
+    const floatingLabelText = props.floatingLabelText || props.placeholder || null;
+    props.placeholder = props.placeholder || props.floatingLabelText || null;
+    delete props.useFloatingLabel;
+    delete props.floatingLabelText;
+    return (<Hint shouldSelect={shouldSelectHint}>
+            <div className={useFloatingLabel ? "form-floating" : ""}>
+                <Input
+                    {...props}
+                    ref={(node) => {
+                        inputRef(node);
+                        referenceElementRef(node);
+                    }}
+                />
+                {useFloatingLabel && <label htmlFor={props.id}>{floatingLabelText}</label>}
+            </div>
+        </Hint>
+    )
+});

--- a/src/components/TypeaheadInputSingle.js
+++ b/src/components/TypeaheadInputSingle.js
@@ -27,7 +27,7 @@ export default withClassNames(({
     delete props.useFloatingLabel;
     delete props.floatingLabelText;
     return (<Hint shouldSelect={shouldSelectHint}>
-            <div className={useFloatingLabel ? "form-floating" : ""}>
+            <div className={`w-100 ${useFloatingLabel ? "form-floating" : ""}`}>
                 <Input
                     {...props}
                     ref={(node) => {

--- a/styles/Typeahead.scss
+++ b/styles/Typeahead.scss
@@ -91,7 +91,7 @@ $rbt-placeholder-color: #6c757d !default;
     }
 
     // Safari and Chrome
-    &::-webkit-input-placeholder  {
+    &::-webkit-input-placeholder {
       color: $rbt-placeholder-color;
     }
   }
@@ -174,6 +174,17 @@ $rbt-token-active-color: $rbt-color-white !default;
     right: 0;
     text-shadow: none;
     top: -2px;
+    background-color: transparent;
+    border: none;
+  }
+}
+
+//token inside multi select divs with floating labels
+.rbt-multi-input-floating-label .rbt-token {
+  align-self: center;
+
+  &:first-of-type {
+    margin-left: .75rem;
   }
 }
 


### PR DESCRIPTION
**What issue does this pull request resolve?**

Floating labels were added in Bootstrap 5, but are not supported in react-bootstrap-typeahead yet (part of issue #622)

**What changes did you make?**

1. Wrap `<Input/>` componenets in a div which if `inputProps.useFloatingLabels === true` will add the `form-floating` class
2. Immediately following `<Input/>` component a `<label>` element will render if `inputProps.useFloatingLabels === true`
3. `inputProps.useFloatingLabels` and `inputProps.floatingLabelText` are deleted before being passed on to the `<Input/>` component to avoid React warnings
4. Multi inputs padding is 0 when `inputProps.useFloatingLabels === true` to keep alignment as expected with floating label
5. Multi inputs have special `rbt-multi-input-floating-label` class apllied when `inputProps.useFloatingLabels === true` to help adjust token styling
6. Tokens have `align-self: center` and margin adjustments to keep styling as expected only when `inputProps.useFloatingLabels === true`
7. Added floating label section to examples page

To enable a floating label `inputProps` must contain the following:

- `id` (unique to the input itself)
- `useFloatingLabels: true`
- `floatingLabelText` - Bootstrap requires a placeholder which will fallback to this if not set

**Is there anything that requires more attention while reviewing?**

- [ ] Vertical alignment on the multi tokens and non-focussed label is a tiny bit off, not sure where the exact cause is and didn't want to mess with styling too much
- [ ] 6 tests failed but I don't understand the output; [I've attached it as a txt file](https://github.com/ericgio/react-bootstrap-typeahead/files/6974538/test.21-08-12.1100.txt), would really appreciate your guidance here as I don't want to break anything
- [ ] Needs linting - I haven't used it before and I think mine isn't set to match your settings, as it reports 9814 problems in every file


