### PR TITLE
Always call onChange when clear button is pressed.

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -10,13 +10,13 @@
     "gzipped": 32011
   },
   "react-bootstrap-typeahead.js": {
-    "bundled": 324825,
-    "minified": 107029,
-    "gzipped": 36974
+    "bundled": 324892,
+    "minified": 107070,
+    "gzipped": 36977
   },
   "react-bootstrap-typeahead.min.js": {
-    "bundled": 292778,
-    "minified": 98227,
-    "gzipped": 34192
+    "bundled": 292845,
+    "minified": 98268,
+    "gzipped": 34194
   }
 }

--- a/src/__tests__/components/Typeahead.test.js
+++ b/src/__tests__/components/Typeahead.test.js
@@ -1267,7 +1267,7 @@ describe('<Typeahead> `change` events', () => {
     }
   );
 
-  it('calls change events when clicking the clear button', () => {
+  it('calls change events when clicking the clear button on single', () => {
     let event, value;
 
     onInputChange = jest.fn((v, e) => {
@@ -1285,6 +1285,33 @@ describe('<Typeahead> `change` events', () => {
     );
 
     screen.getByRole('button').click();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onInputChange).toHaveBeenCalledTimes(1);
+    expect(value).toBe('');
+    expect(event).toBeDefined();
+  });
+
+  it('calls change events when clicking the clear button on multiple', () => {
+    let event, value;
+
+    onInputChange = jest.fn((v, e) => {
+      value = v;
+      event = e;
+    });
+
+    render(
+      <TestComponent
+        multiple
+        clearButton
+        defaultInputValue="test"
+        onChange={onChange}
+        onInputChange={onInputChange}
+        selected={states.slice(0, 1)}
+      />
+    );
+
+    screen.getByLabelText('Clear').click();
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onInputChange).toHaveBeenCalledTimes(1);

--- a/src/core/Typeahead.js
+++ b/src/core/Typeahead.js
@@ -469,7 +469,12 @@ class Typeahead extends React.Component<Props, TypeaheadState> {
 
   _handleClear = () => {
     this.inputNode && triggerInputChange(this.inputNode, '');
-    this.setState(clearTypeahead);
+    this.setState(clearTypeahead, () => {
+      // Clearing the input fields triggers this for single select mode.
+      if (this.props.multiple) {
+        this._handleChange([]);
+      }
+    });
   }
 
   _handleFocus = (e: SyntheticEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Commit 683c2687d4d706e42112749fba0d6aba4f0fa1d9 broke this on multi
select mode. As result the internal state of the Typeahead component
was cleared and it appeared empty, but later refocusing the element,
would cause the previously selected options to show up again, as the
clearing had not been propagated to the parent component.

**What issue does this pull request resolve?**
V5.2.0 broke clearButton on multiple select mode.

**What changes did you make?**
Conditionally calling _handleChange in _handleClear in multiple mode.
Also added a test case.

**Is there anything that requires more attention while reviewing?**
Nope.