### PR TITLE
In 'multiple' mode keep menu opened while pressing Ctrl key.

### DIFF
--- a/src/core/Typeahead.js
+++ b/src/core/Typeahead.js
@@ -558,7 +558,7 @@ class Typeahead extends React.Component<Props, TypeaheadState> {
     if (option.paginationOption) {
       this._handlePaginate(e);
     } else {
-      this._handleSelectionAdd(option);
+      this._handleSelectionAdd(option, (e: any).ctrlKey);
     }
   }
 
@@ -570,7 +570,7 @@ class Typeahead extends React.Component<Props, TypeaheadState> {
     }), () => this.props.onPaginate(e, this.state.shownResults));
   }
 
-  _handleSelectionAdd = (option: Option) => {
+  _handleSelectionAdd = (option: Option, doNotCloseMenu?: boolean) => {
     const { multiple, labelKey } = this.props;
 
     let selected;
@@ -587,7 +587,8 @@ class Typeahead extends React.Component<Props, TypeaheadState> {
       // If multiple selections are allowed, add the new selection to the
       // existing selections.
       selected = this.state.selected.concat(selection);
-      text = '';
+      // keep text in input in case of pressed ctrl key
+      text = doNotCloseMenu ? this.state.text : '';
     } else {
       // If only a single selection is allowed, replace the existing selection
       // with the new one.
@@ -596,7 +597,8 @@ class Typeahead extends React.Component<Props, TypeaheadState> {
     }
 
     this.setState((state, props) => ({
-      ...hideMenu(state, props),
+      // do not hide menu in case of pressed ctrl key
+      ...(multiple && doNotCloseMenu ? {} : hideMenu(state, props)),
       initialItem: selection,
       selected,
       text,

--- a/src/core/Typeahead.js
+++ b/src/core/Typeahead.js
@@ -587,10 +587,7 @@ class Typeahead extends React.Component<Props, TypeaheadState> {
       // If multiple selections are allowed, add the new selection to the
       // existing selections.
       selected = this.state.selected.concat(selection);
-<<<<<<< HEAD
       // keep text in input in case of pressed ctrl key
-=======
->>>>>>> 30fe8642bcd7c30cc42decb95a9a67421af6e125
       text = doNotCloseMenu ? this.state.text : '';
     } else {
       // If only a single selection is allowed, replace the existing selection
@@ -600,10 +597,7 @@ class Typeahead extends React.Component<Props, TypeaheadState> {
     }
 
     this.setState((state, props) => ({
-<<<<<<< HEAD
       // do not hide menu in case of pressed ctrl key
-=======
->>>>>>> 30fe8642bcd7c30cc42decb95a9a67421af6e125
       ...(multiple && doNotCloseMenu ? {} : hideMenu(state, props)),
       initialItem: selection,
       selected,


### PR DESCRIPTION
I think it is useful to be able to have menu with choices opened while selecting multiple values. These very minor changes allow user to press Ctrl key during selection so menu stays opened.

Still thinking how to make it work for touch UI.

Thank you