### PR TITLE
Fix filter callback return type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export type AllowNew =
 export type FilterByCallback = (
   option: Option,
   state: TypeaheadPropsAndState
-) => void;
+) => boolean;
 
 export type Id = string;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request.

Before continuing, please read the guidelines:
https://github.com/ericgio/react-bootstrap-typeahead/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**

I opted not to create a GitHub issue for this simple type fix. The issue is that the type of `FilterByCallback` should be `boolean` and currently it is `void`.

**What changes did you make?**

Changed the return type of the `FilterByCallback` to `boolean`.

**Is there anything that requires more attention while reviewing?**

No.