### PR TITLE
Tests should not depend on the system locale

### DIFF
--- a/src/components/TypeaheadMenu/TypeaheadMenu.stories.tsx
+++ b/src/components/TypeaheadMenu/TypeaheadMenu.stories.tsx
@@ -57,7 +57,7 @@ CustomChildren.args = {
       <>
         <div>{name}</div>
         <div>
-          <small>Population: {population.toLocaleString()}</small>
+          <small>Population: {population.toString()}</small>
         </div>
       </>
     );

--- a/src/components/TypeaheadMenu/__snapshots__/TypeaheadMenu.test.tsx.snap
+++ b/src/components/TypeaheadMenu/__snapshots__/TypeaheadMenu.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            4,780,127
+            4780127
           </small>
         </div>
       </a>
@@ -65,7 +65,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            710,249
+            710249
           </small>
         </div>
       </a>
@@ -85,7 +85,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            6,392,307
+            6392307
           </small>
         </div>
       </a>
@@ -105,7 +105,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            2,915,958
+            2915958
           </small>
         </div>
       </a>
@@ -125,7 +125,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            37,254,503
+            37254503
           </small>
         </div>
       </a>
@@ -145,7 +145,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            5,029,324
+            5029324
           </small>
         </div>
       </a>
@@ -165,7 +165,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            3,574,118
+            3574118
           </small>
         </div>
       </a>
@@ -185,7 +185,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            897,936
+            897936
           </small>
         </div>
       </a>
@@ -205,7 +205,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            18,804,623
+            18804623
           </small>
         </div>
       </a>
@@ -225,7 +225,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            9,688,681
+            9688681
           </small>
         </div>
       </a>
@@ -245,7 +245,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            1,360,301
+            1360301
           </small>
         </div>
       </a>
@@ -265,7 +265,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            1,567,652
+            1567652
           </small>
         </div>
       </a>
@@ -285,7 +285,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            12,831,549
+            12831549
           </small>
         </div>
       </a>
@@ -305,7 +305,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            6,484,229
+            6484229
           </small>
         </div>
       </a>
@@ -325,7 +325,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            3,046,869
+            3046869
           </small>
         </div>
       </a>
@@ -345,7 +345,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            2,853,132
+            2853132
           </small>
         </div>
       </a>
@@ -365,7 +365,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            4,339,349
+            4339349
           </small>
         </div>
       </a>
@@ -385,7 +385,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            4,533,479
+            4533479
           </small>
         </div>
       </a>
@@ -405,7 +405,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            1,328,361
+            1328361
           </small>
         </div>
       </a>
@@ -425,7 +425,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            5,773,785
+            5773785
           </small>
         </div>
       </a>
@@ -445,7 +445,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            6,547,817
+            6547817
           </small>
         </div>
       </a>
@@ -465,7 +465,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            9,884,129
+            9884129
           </small>
         </div>
       </a>
@@ -485,7 +485,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            5,303,925
+            5303925
           </small>
         </div>
       </a>
@@ -505,7 +505,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            2,968,103
+            2968103
           </small>
         </div>
       </a>
@@ -525,7 +525,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            5,988,927
+            5988927
           </small>
         </div>
       </a>
@@ -545,7 +545,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            989,417
+            989417
           </small>
         </div>
       </a>
@@ -565,7 +565,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            1,826,341
+            1826341
           </small>
         </div>
       </a>
@@ -585,7 +585,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            2,700,691
+            2700691
           </small>
         </div>
       </a>
@@ -605,7 +605,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            1,316,466
+            1316466
           </small>
         </div>
       </a>
@@ -625,7 +625,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            8,791,936
+            8791936
           </small>
         </div>
       </a>
@@ -645,7 +645,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            2,059,192
+            2059192
           </small>
         </div>
       </a>
@@ -665,7 +665,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            19,378,087
+            19378087
           </small>
         </div>
       </a>
@@ -685,7 +685,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            9,535,692
+            9535692
           </small>
         </div>
       </a>
@@ -705,7 +705,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            672,591
+            672591
           </small>
         </div>
       </a>
@@ -725,7 +725,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            11,536,725
+            11536725
           </small>
         </div>
       </a>
@@ -745,7 +745,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            3,751,616
+            3751616
           </small>
         </div>
       </a>
@@ -765,7 +765,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            3,831,073
+            3831073
           </small>
         </div>
       </a>
@@ -785,7 +785,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            12,702,887
+            12702887
           </small>
         </div>
       </a>
@@ -805,7 +805,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            1,052,931
+            1052931
           </small>
         </div>
       </a>
@@ -825,7 +825,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            4,625,401
+            4625401
           </small>
         </div>
       </a>
@@ -845,7 +845,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            814,191
+            814191
           </small>
         </div>
       </a>
@@ -865,7 +865,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            6,346,275
+            6346275
           </small>
         </div>
       </a>
@@ -885,7 +885,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            25,146,105
+            25146105
           </small>
         </div>
       </a>
@@ -905,7 +905,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            2,763,888
+            2763888
           </small>
         </div>
       </a>
@@ -925,7 +925,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            625,745
+            625745
           </small>
         </div>
       </a>
@@ -945,7 +945,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            8,001,045
+            8001045
           </small>
         </div>
       </a>
@@ -965,7 +965,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            6,724,543
+            6724543
           </small>
         </div>
       </a>
@@ -985,7 +985,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            1,853,011
+            1853011
           </small>
         </div>
       </a>
@@ -1005,7 +1005,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            5,687,289
+            5687289
           </small>
         </div>
       </a>
@@ -1025,7 +1025,7 @@ exports[`<TypeaheadMenu> CustomChildren story renders snapshot 1`] = `
         <div>
           <small>
             Population: 
-            563,767
+            563767
           </small>
         </div>
       </a>


### PR DESCRIPTION
One of the tests was using locale specific number formatting, and broke the test when running in a system that is not using a comma as a thousands separator.