### PR TITLE
Change useLayoutEffect to useIsomorphicLayoutEffect

### DIFF
--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -4,10 +4,10 @@ import {
   CSSProperties,
   ReactElement,
   RefCallback,
-  useLayoutEffect,
   useState,
 } from 'react';
 import { usePopper } from 'react-popper';
+import useIsomorphicLayoutEffect from '../../hooks/useIsomorphicLayoutEffect';
 
 import { noop } from '../../utils';
 
@@ -115,7 +115,7 @@ const Overlay = ({ referenceElement, ...props }: OverlayProps) => {
 
   // Re-position the popper if the height of the reference element changes.
   // Exclude `forceUpdate` from dependencies since it changes with each render.
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     forceUpdate && forceUpdate();
   }, [refElementHeight]); // eslint-disable-line
 

--- a/src/hooks/useIsomorphicLayoutEffect-jsdom.test.ts
+++ b/src/hooks/useIsomorphicLayoutEffect-jsdom.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment jsdom
+ */
+import { useLayoutEffect } from 'react';
+import useIsomorphicLayoutEffect from "./useIsomorphicLayoutEffect";
+
+describe('useIsomorphicLayoutEffect in jsdom', () => {
+    it('window in browser', () => {
+        expect(useIsomorphicLayoutEffect).toEqual(useLayoutEffect);
+    });
+})

--- a/src/hooks/useIsomorphicLayoutEffect-node.test.ts
+++ b/src/hooks/useIsomorphicLayoutEffect-node.test.ts
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import useIsomorphicLayoutEffect from "./useIsomorphicLayoutEffect";
 
 describe('useIsomorphicLayoutEffect in node', () => {
-    it('window in browser', () => {
+    it('window in node', () => {
         expect(useIsomorphicLayoutEffect).toEqual(useEffect);
     });
 });

--- a/src/hooks/useIsomorphicLayoutEffect-node.test.ts
+++ b/src/hooks/useIsomorphicLayoutEffect-node.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+import { useEffect } from 'react';
+import useIsomorphicLayoutEffect from "./useIsomorphicLayoutEffect";
+
+describe('useIsomorphicLayoutEffect in node', () => {
+    it('window in browser', () => {
+        expect(useIsomorphicLayoutEffect).toEqual(useEffect);
+    });
+});

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,5 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;


### PR DESCRIPTION
**What issue does this pull request resolve?**
- https://github.com/ericgio/react-bootstrap-typeahead/issues/756

Hello! react-bootstrap-typeahead very good 😄 
but, I'm seeing the same issue, so I'd like to fix it.

**What changes did you make?**
- Avoid useLayoutEffect waring

**Is there anything that requires more attention while reviewing?**
- ref : https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85