### PR TITLE
Prop for tab selecting option from menu (#788)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -67,6 +67,7 @@ renderToken | function | | Callback for custom token rendering. See full documen
 selected | Array\<Object\|string\> | `[]` | The selected option(s) displayed in the input. Use this prop if you want to control the component via its parent.
 selectHint | function | | Callback function that determines whether the hint should be selected.<br><br><pre>`(shouldSelectHint: boolean, KeyboardEvent<HTMLInputElement>) => boolean`</pre>
 size | `'lg'` \| `'sm'` | | Specify the size of the input.
+selectOptionOnTab | boolean | false | Lets Tab choose selected option in menu instead of behaving like tabbing out of a standard input
 
 #### Children
 In addition to the props listed above, `Typeahead` also accepts either children or a child render function.

--- a/src/components/Typeahead/Typeahead.test.tsx
+++ b/src/components/Typeahead/Typeahead.test.tsx
@@ -881,6 +881,34 @@ describe('<Typeahead>', () => {
     expect(getMenu()).not.toBeInTheDocument();
   });
 
+  it('hides the menu when tabbing out of the input with selectOptionOnTab and no active item', async () => {
+    const user = userEvent.setup();
+    render(<Default selectOptionOnTab />);
+
+    const input = getInput();
+    input.focus();
+
+    await user.keyboard('{ArrowDown}{ArrowUp}');
+    await user.tab();
+
+    expect(getMenu()).not.toBeInTheDocument();
+    expect(input).toHaveValue('');
+  });
+
+  it('selects active item on tabbing out of menu with selectOptionOnTab prop', async () => {
+    const user = userEvent.setup();
+    render(<Default selectOptionOnTab />);
+
+    const input = getInput();
+    input.focus();
+
+    await user.keyboard('{ArrowDown}');
+    await user.tab();
+
+    expect(input).toHaveValue('Alabama');
+    expect(getMenu()).not.toBeInTheDocument();
+  });
+
   it('calls the keydown handler when a key is pressed', async () => {
     const user = userEvent.setup();
     const onKeyDown = jest.fn();

--- a/src/core/Typeahead.tsx
+++ b/src/core/Typeahead.tsx
@@ -188,6 +188,10 @@ const propTypes = {
    * to control the component via its parent.
    */
   selected: checkPropType(PropTypes.arrayOf(optionType), selectedType),
+  /**
+   * Whether pressing Tab is selecting the active item in the menu.
+   */
+  selectOptionOnTab: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -211,6 +215,7 @@ const defaultProps = {
   onMenuToggle: noop,
   onPaginate: noop,
   paginate: true,
+  selectOptionOnTab: false,
 };
 
 type Props = TypeaheadProps;
@@ -476,10 +481,14 @@ class Typeahead extends React.Component<Props, TypeaheadState> {
         activeItem && this._handleMenuItemSelect(activeItem, e);
         break;
       case 'Escape':
-      case 'Tab':
-        // ESC simply hides the menu. TAB will blur the input and move focus to
-        // the next item; hide the menu so it doesn't gain focus.
         this.hideMenu();
+        break;
+      case 'Tab':
+        if (this.props.selectOptionOnTab && activeItem) {
+           this._handleMenuItemSelect(activeItem, e);
+        } else {
+          this.hideMenu();
+        }
         break;
       default:
         break;

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,7 @@ export interface TypeaheadProps {
   paginate: boolean;
   selected?: Option[];
   selectHint?: SelectHint;
+  selectOptionOnTab?: boolean;
 }
 
 export interface TypeaheadState {


### PR DESCRIPTION
**What issue does this pull request resolve?**
#788 Tab not selecting active item in menu

**What changes did you make?**
Implemented prop `selectOptionOnTab` to enable possibility to make tab selecting the active item in menu