### PR TITLE
`defaultProps` for functional components are deprecated

### DIFF
--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -40,7 +40,7 @@ const defaultProps = {
   flip: false,
   isMenuShown: false,
   positionFixed: false,
-};
+} as const;
 
 export interface OverlayRenderProps {
   innerRef: RefCallback<HTMLElement>;
@@ -53,8 +53,8 @@ export interface OverlayProps extends OverlayOptions {
   referenceElement: ReferenceElement;
 }
 
-const Overlay = ({ referenceElement, isMenuShown, ...props }: OverlayProps) => {
-  const overlayProps = useOverlay(referenceElement, props);
+const Overlay = ({ referenceElement, isMenuShown = defaultProps.isMenuShown, ...props }: OverlayProps) => {
+  const overlayProps = useOverlay(referenceElement, { ...defaultProps, ...props });
 
   if (!isMenuShown) {
     return null;
@@ -64,6 +64,5 @@ const Overlay = ({ referenceElement, isMenuShown, ...props }: OverlayProps) => {
 };
 
 Overlay.propTypes = propTypes;
-Overlay.defaultProps = defaultProps;
 
 export default Overlay;

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -34,14 +34,6 @@ const propTypes = {
   referenceElement: PropTypes.instanceOf(SafeElement),
 };
 
-const defaultProps = {
-  align: 'justify',
-  dropup: false,
-  flip: false,
-  isMenuShown: false,
-  positionFixed: false,
-} as const;
-
 export interface OverlayRenderProps {
   innerRef: RefCallback<HTMLElement>;
   style: CSSProperties;
@@ -53,8 +45,8 @@ export interface OverlayProps extends OverlayOptions {
   referenceElement: ReferenceElement;
 }
 
-const Overlay = ({ referenceElement, isMenuShown = defaultProps.isMenuShown, ...props }: OverlayProps) => {
-  const overlayProps = useOverlay(referenceElement, { ...defaultProps, ...props });
+const Overlay = ({ referenceElement, isMenuShown, ...props }: OverlayProps) => {
+  const overlayProps = useOverlay(referenceElement, props);
 
   if (!isMenuShown) {
     return null;


### PR DESCRIPTION

**What issue does this pull request resolve?**
#791 

**What changes did you make?**
This is a cheap solution that does not improve the performance (it is a non-issue for `Overlay`), but removes the warning without changing the overall design or the unit testing

**Is there anything that requires more attention while reviewing?**
No