### PR TITLE
Strip Japanese diacritics

### DIFF
--- a/src/utils/stripDiacritics.ts
+++ b/src/utils/stripDiacritics.ts
@@ -114,7 +114,7 @@ export default function stripDiacritics(str: string): string {
   return (
     str
       .normalize('NFD')
-      .replace(/[\u0300-\u036F]/g, '') // Remove combining diacritics
+      .replace(/[\u0300-\u036F\u3099\u309A]/g, '') // Remove combining diacritics
       /* eslint-disable-next-line no-control-regex */
       .replace(/[^\u0000-\u007E]/g, (a) => map[a] || a)
   );


### PR DESCRIPTION


<!--
Thank you for submitting a pull request.

Before continuing, please read the guidelines:
https://github.com/ericgio/react-bootstrap-typeahead/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
Issue #806

**What changes did you make?**
Added Japanese diacritics to the list of diacritics being stripped by the RegExp.

**Is there anything that requires more attention while reviewing?**
Consider normalizing the resulting string back to NFC before returning from `stripDiacritics`.
If any other diacritics were missed, or if the conversion to NFD caused other decompositions other than diacritics, the NFD string will be longer, causing the highlighting to be offset. Normalizing back to NFC avoids this. This can be done by adding `.normalize('NFC')` on a new line in between line 119 and line 120.