### PR TITLE
don't skip options with a falsey disabled value

### DIFF
--- a/src/utils/getUpdatedActiveIndex.test.ts
+++ b/src/utils/getUpdatedActiveIndex.test.ts
@@ -7,7 +7,8 @@ const options = [
   { name: 'foo' },
   { disabled: true, name: 'bar' },
   { disabled: true, name: 'boo' },
-  { name: 'baz' },
+  { name: 'baz', disabled: false },
+  { name: 'bja', disabled: undefined },
 ];
 
 const stringOptions = ['foo', 'bar', 'baz'];
@@ -15,9 +16,11 @@ const stringOptions = ['foo', 'bar', 'baz'];
 test('getUpdatedActiveIndex', () => {
   expect(getUpdatedActiveIndex(-1, 'ArrowDown', options)).toBe(0);
   expect(getUpdatedActiveIndex(0, 'ArrowDown', options)).toBe(3);
-  expect(getUpdatedActiveIndex(3, 'ArrowDown', options)).toBe(-1);
+  expect(getUpdatedActiveIndex(3, 'ArrowDown', options)).toBe(4);
+  expect(getUpdatedActiveIndex(4, 'ArrowDown', options)).toBe(-1);
 
-  expect(getUpdatedActiveIndex(-1, 'ArrowUp', options)).toBe(3);
+  expect(getUpdatedActiveIndex(-1, 'ArrowUp', options)).toBe(4);
+  expect(getUpdatedActiveIndex(4, 'ArrowUp', options)).toBe(3);
   expect(getUpdatedActiveIndex(3, 'ArrowUp', options)).toBe(0);
   expect(getUpdatedActiveIndex(0, 'ArrowUp', options)).toBe(-1);
 });
@@ -36,6 +39,8 @@ test('skipDisabledOptions', () => {
 test('isDisabledOption', () => {
   expect(isDisabledOption(0, options)).toBe(false);
   expect(isDisabledOption(1, options)).toBe(true);
+  expect(isDisabledOption(3, options)).toBe(false);
+  expect(isDisabledOption(4, options)).toBe(false);
   expect(isDisabledOption(6, options)).toBe(false);
   expect(isDisabledOption(0, stringOptions)).toBe(false);
 });

--- a/src/utils/getUpdatedActiveIndex.ts
+++ b/src/utils/getUpdatedActiveIndex.ts
@@ -1,12 +1,11 @@
 import type { Option } from '../types';
-import { isString } from './nodash';
-import hasOwnProperty from './hasOwnProperty';
+import getOptionProperty from './getOptionProperty';
 
 type Key = 'ArrowDown' | 'ArrowUp';
 
 export function isDisabledOption(index: number, items: Option[]): boolean {
   const option = items[index];
-  return !!option && !isString(option) && hasOwnProperty(option, 'disabled');
+  return !!option && !!getOptionProperty(option, 'disabled');
 }
 
 export function skipDisabledOptions(


### PR DESCRIPTION
**What issue does this pull request resolve?**

#818

**What changes did you make?**

Updated the disabled check used for keyboard selection of options to match the general disabled check for options (previously it was considering the option disabled if it had a property named `disabled`, rather than looking at the value of that property.)

