### PR TITLE
Remove default props error message / warning

### DIFF
--- a/src/components/ClearButton/ClearButton.tsx
+++ b/src/components/ClearButton/ClearButton.tsx
@@ -14,10 +14,6 @@ const propTypes = {
   size: sizeType,
 };
 
-const defaultProps = {
-  label: 'Clear',
-};
-
 export interface ClearButtonProps
   extends Omit<HTMLProps<HTMLButtonElement>, 'size'> {
   label: string;
@@ -31,7 +27,7 @@ export interface ClearButtonProps
  */
 const ClearButton = ({
   className,
-  label,
+  label = 'Clear',
   onClick,
   onKeyDown,
   size,
@@ -70,6 +66,5 @@ const ClearButton = ({
 );
 
 ClearButton.propTypes = propTypes;
-ClearButton.defaultProps = defaultProps;
 
 export default ClearButton;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request.

Before continuing, please read the guidelines:
https://github.com/ericgio/react-bootstrap-typeahead/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
#823 

**What changes did you make?**
This is a cheap solution that does not improve the performance (it is a non-issue for ClearButton), but removes the warning without changing the overall design or the unit testing

**Is there anything that requires more attention while reviewing?**
No