### PR TITLE
Long option causes menu to open in wrong position issue

### DIFF
--- a/src/components/Overlay/Overlay.test.tsx
+++ b/src/components/Overlay/Overlay.test.tsx
@@ -99,15 +99,15 @@ describe('Overlay modifiers', () => {
     const props: ModifierProps = { align: 'justify', flip: false };
 
     const modifiers = getModifiers(props);
-    expect(modifiers).toHaveLength(2);
+    expect(modifiers).toHaveLength(3);
     expect(
       modifiers.find(({ name }) => name === 'setPopperWidth')
     ).toBeTruthy();
 
     props.align = 'left';
-    expect(getModifiers(props)).toHaveLength(1);
+    expect(getModifiers(props)).toHaveLength(2);
 
     props.align = 'right';
-    expect(getModifiers(props)).toHaveLength(1);
+    expect(getModifiers(props)).toHaveLength(2);
   });
 });

--- a/src/components/Overlay/useOverlay.ts
+++ b/src/components/Overlay/useOverlay.ts
@@ -29,6 +29,12 @@ export function getModifiers(props: Pick<OverlayOptions, 'align' | 'flip'>) {
       enabled: !!props.flip,
       name: 'flip',
     },
+    {
+      name: 'preventOverflow',
+      options: {
+        mainAxis: false
+      }
+    }
   ];
 
   if (props.align !== 'right' && props.align !== 'left') {
@@ -63,7 +69,7 @@ export function useOverlay(
   );
 
   const refElementHeight = referenceElement?.offsetHeight;
-
+  
   // Re-position the popper if the height of the reference element changes.
   // Exclude `forceUpdate` from dependencies since it changes with each render.
   useEffect(() => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request.

Before continuing, please read the guidelines:
https://github.com/ericgio/react-bootstrap-typeahead/blob/master/CONTRIBUTING.md#pull-requests

If the pull request contains code please make sure there is an issue that we agreed to resolve (if it is a documentation improvement there is no need for an issue).

Please answer the questions below.
-->

**What issue does this pull request resolve?**
#776

**What changes did you make?**
I added a popperjs modifier that will disable popperjs from trying to prevent over flow on a menu for options

**Is there anything that requires more attention while reviewing?**
No
