### PR TITLE
make it clearer that isValid and isInvalid work for 5 too

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -44,9 +44,9 @@ highlightOnlyResult | boolean | false | Highlights the menu item if there is onl
 id `required` | string or number | | An html id attribute, required for assistive technologies such as screen readers.
 ignoreDiacritics | boolean | true | Whether the filter should ignore accents and other diacritical marks.
 inputProps | object | {} | Props to be applied directly to the input. `onBlur`, `onChange`, `onFocus`, and `onKeyDown` are ignored.
-isInvalid | boolean | false | Adds the `is-invalid` classname to the `form-control`. Only affects Bootstrap 4.
+isInvalid | boolean | false | Adds the `is-invalid` classname to the `form-control`. Only affects Bootstrap 4 and above.
 isLoading | boolean | false | Indicate whether an asynchronous data fetch is happening.
-isValid | boolean | false | Adds the `is-valid` classname to the `form-control`. Only affects Bootstrap 4.
+isValid | boolean | false | Adds the `is-valid` classname to the `form-control`. Only affects Bootstrap 4 and above.
 labelKey | string \| function | `'label'` | See full documentation in the [Rendering section](Rendering.md#labelkey-string--function).
 minLength | number | 0 | Minimum user input before displaying results.
 onChange | function | | Invoked when the set of selections changes (ie: an item is added or removed). For consistency, `selected` is always an array of selections, even if multi-selection is not enabled. <br><br><pre>`(selected: Array<Object\|string>) => void`</pre>


### PR DESCRIPTION
**What issue does this pull request resolve?**

Minor documentation change to isValid and isInvalid props

**What changes did you make?**

This current wording mislead me at first to assume this would not work with Bootstrap 5 for some reason;  but it actually does,  so I made that more clear.
(I assume it was originally written before 5 was released)

**Is there anything that requires more attention while reviewing?**
No